### PR TITLE
8254940: AArch64: Cleanup non-product thread members

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
@@ -27,15 +27,6 @@
 #define OS_CPU_LINUX_AARCH64_THREAD_LINUX_AARCH64_HPP
 
  private:
-#ifdef ASSERT
-  // spill stack holds N callee-save registers at each Java call and
-  // grows downwards towards limit
-  // we need limit to check we have space for a spill and base so we
-  // can identify all live spill frames at GC (eventually)
-  address          _spill_stack;
-  address          _spill_stack_base;
-  address          _spill_stack_limit;
-#endif // ASSERT
 
   void pd_initialize() {
     _anchor.clear();


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8254940

В патче убрали неиспользуемые поля. Я тоже проверил, что они не используются

Там в патче был ещё файл thread_windows_aarch64.hpp, но в jdk15 его ещё не было, поэтому был конфликт при бекпортировании, нужно было сказать, что такой файл не нужен. Но бекпорт чистый)