### PR TITLE
8254270: linux 32 bit build doesn't compile libjdwp/log_messages.c

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,12 @@ get_time_stamp(char *tbuf, size_t ltbuf)
                 "%d.%m.%Y %T", localtime(&t));
     (void)strftime(timestamp_timezone, TZ_SIZE,
                 "%Z", localtime(&t));
-    (void)snprintf(tbuf, ltbuf,
-                   "%s.%.3d %s", timestamp_date_time,
-                   (int)(millisecs), timestamp_timezone);
+
+    // Truncate milliseconds in buffer large enough to hold the
+    // value which is always < 1000 (and so a maximum of 3 digits for "%.3d")
+    char tmp[20];
+    snprintf(tmp, sizeof(tmp), "%.3d", millisecs);
+    snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
 }
 
 /* Get basename of filename */


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8254270

Патч исправляет проблему из-за которой jdk не компилируется на linux x86