### PR TITLE
8263068: Rename safefetch.hpp to safefetch.inline.hpp 

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -63,7 +63,7 @@
 #include "runtime/os.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/perfMemory.hpp"
-#include "runtime/safefetch.hpp"
+#include "runtime/safefetch.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/statSampler.hpp"
 #include "runtime/thread.inline.hpp"

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -34,7 +34,7 @@
 #include "logging/log.hpp"
 #include "runtime/init.hpp"
 #include "runtime/os.hpp"
-#include "runtime/safefetch.hpp"
+#include "runtime/safefetch.inline.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/growableArray.hpp"

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -56,7 +56,7 @@
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/perfMemory.hpp"
-#include "runtime/safefetch.hpp"
+#include "runtime/safefetch.inline.hpp"
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/statSampler.hpp"

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -36,7 +36,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/os.hpp"
-#include "runtime/safefetch.hpp"
+#include "runtime/safefetch.inline.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/align.hpp"

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -40,15 +40,7 @@
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
-<<<<<<< HEAD
-#include "runtime/safefetch.hpp"
-||||||| parent of 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
-#include "runtime/perfData.hpp"
-#include "runtime/safefetch.hpp"
-=======
-#include "runtime/perfData.hpp"
 #include "runtime/safefetch.inline.hpp"
->>>>>>> 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
 #include "runtime/safepointMechanism.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/thread.inline.hpp"

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -40,7 +40,15 @@
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
+<<<<<<< HEAD
 #include "runtime/safefetch.hpp"
+||||||| parent of 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
+#include "runtime/perfData.hpp"
+#include "runtime/safefetch.hpp"
+=======
+#include "runtime/perfData.hpp"
+#include "runtime/safefetch.inline.hpp"
+>>>>>>> 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
 #include "runtime/safepointMechanism.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/thread.inline.hpp"

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -53,15 +53,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/os.inline.hpp"
-<<<<<<< HEAD
-#include "runtime/safefetch.hpp"
-||||||| parent of 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
-#include "runtime/osThread.hpp"
-#include "runtime/safefetch.hpp"
-=======
-#include "runtime/osThread.hpp"
 #include "runtime/safefetch.inline.hpp"
->>>>>>> 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/threadSMR.hpp"

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -53,7 +53,15 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/os.inline.hpp"
+<<<<<<< HEAD
 #include "runtime/safefetch.hpp"
+||||||| parent of 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
+#include "runtime/osThread.hpp"
+#include "runtime/safefetch.hpp"
+=======
+#include "runtime/osThread.hpp"
+#include "runtime/safefetch.inline.hpp"
+>>>>>>> 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/threadSMR.hpp"

--- a/src/hotspot/share/runtime/safefetch.inline.hpp
+++ b/src/hotspot/share/runtime/safefetch.inline.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef SHARE_RUNTIME_SAFEFETCH_HPP
-#define SHARE_RUNTIME_SAFEFETCH_HPP
+#ifndef SHARE_RUNTIME_SAFEFETCH_INLINE_HPP
+#define SHARE_RUNTIME_SAFEFETCH_INLINE_HPP
 
 #include "runtime/stubRoutines.hpp"
 
@@ -48,4 +48,4 @@ inline bool CanUseSafeFetchN() {
   return StubRoutines::SafeFetchN_stub() ? true : false;
 }
 
-#endif // SHARE_RUNTIME_SAFEFETCH_HPP
+#endif // SHARE_RUNTIME_SAFEFETCH_INLINE_HPP

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -30,7 +30,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/timerTrace.hpp"
-#include "runtime/safefetch.hpp"
+#include "runtime/safefetch.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -41,7 +41,15 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/init.hpp"
 #include "runtime/os.hpp"
+<<<<<<< HEAD
 #include "runtime/safefetch.hpp"
+||||||| parent of 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
+#include "runtime/osThread.hpp"
+#include "runtime/safefetch.hpp"
+=======
+#include "runtime/osThread.hpp"
+#include "runtime/safefetch.inline.hpp"
+>>>>>>> 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/threadSMR.hpp"

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -41,15 +41,7 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/init.hpp"
 #include "runtime/os.hpp"
-<<<<<<< HEAD
-#include "runtime/safefetch.hpp"
-||||||| parent of 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
-#include "runtime/osThread.hpp"
-#include "runtime/safefetch.hpp"
-=======
-#include "runtime/osThread.hpp"
 #include "runtime/safefetch.inline.hpp"
->>>>>>> 0bc45625b09 (8263068: Rename safefetch.hpp to safefetch.inline.hpp)
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/threadSMR.hpp"


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8263068

В патче переименовали header файл