### PR TITLE
JDK 8253015

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2021c
+tzdata2021e

--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2021a
+tzdata2021c

--- a/make/data/tzdata/africa
+++ b/make/data/tzdata/africa
@@ -53,9 +53,6 @@
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
 # https://www.jstor.org/stable/1774359
 #
-# A reliable and entertaining source about time zones is
-# Derek Howse, Greenwich time and longitude, Philip Wilson Publishers (1997).
-#
 # European-style abbreviations are commonly used along the Mediterranean.
 # For sub-Saharan Africa abbreviations were less standardized.
 # Previous editions of this database used WAT, CAT, SAT, and EAT
@@ -176,8 +173,9 @@ Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Abidjan	-0:16:08 -	LMT	1912
 			 0:00	-	GMT
+Link Africa/Abidjan Africa/Accra	# Ghana
 Link Africa/Abidjan Africa/Bamako	# Mali
-Link Africa/Abidjan Africa/Banjul	# Gambia
+Link Africa/Abidjan Africa/Banjul	# The Gambia
 Link Africa/Abidjan Africa/Conakry	# Guinea
 Link Africa/Abidjan Africa/Dakar	# Senegal
 Link Africa/Abidjan Africa/Freetown	# Sierra Leone
@@ -404,93 +402,8 @@ Zone	Africa/Cairo	2:05:09 -	LMT	1900 Oct
 # Gabon
 # See Africa/Lagos.
 
-# Gambia
-# See Africa/Abidjan.
-
+# The Gambia
 # Ghana
-
-# From P Chan (2020-11-20):
-# Interpretation Amendment Ordinance, 1915 (No.24 of 1915) [1915-11-02]
-# Ordinances of the Gold Coast, Ashanti, Northern Territories 1915, p 69-71
-# https://books.google.com/books?id=ErA-AQAAIAAJ&pg=PA70
-# This Ordinance added "'Time' shall mean Greenwich Mean Time" to the
-# Interpretation Ordinance, 1876.
-#
-# Determination of the Time Ordinance, 1919 (No. 18 of 1919) [1919-11-24]
-# Ordinances of the Gold Coast, Ashanti, Northern Territories 1919, p 75-76
-# https://books.google.com/books?id=MbA-AQAAIAAJ&pg=PA75
-# This Ordinance removed the previous definition of time and introduced DST.
-#
-# Time Determination Ordinance (Cap. 214)
-# The Laws of the Gold Coast (including Togoland Under British Mandate)
-# Vol. II (1937), p 2328
-# https://books.google.com/books?id=Z7M-AQAAIAAJ&pg=PA2328
-# Revised edition of the 1919 Ordinance.
-#
-# Time Determination (Amendment) Ordinance, 1940 (No. 9 of 1940) [1940-04-06]
-# Annual Volume of the Laws of the Gold Coast:
-# Containing All Legislation Enacted During Year 1940, p 22
-# https://books.google.com/books?id=1ao-AQAAIAAJ&pg=PA22
-# This Ordinance changed the forward transition from September to May.
-#
-# Defence (Time Determination Ordinance Amendment) Regulations, 1942
-# (Regulations No. 6 of 1942) [1942-01-31, commenced on 1942-02-08]
-# Annual Volume of the Laws of the Gold Coast:
-# Containing All Legislation Enacted During Year 1942, p 48
-# https://books.google.com/books?id=Das-AQAAIAAJ&pg=PA48
-# These regulations advanced the [standard] time by thirty minutes.
-#
-# Defence (Time Determination Ordinance Amendment (No.2)) Regulations,
-# 1942 (Regulations No. 28 of 1942) [1942-04-25]
-# Annual Volume of the Laws of the Gold Coast:
-# Containing All Legislation Enacted During Year 1942, p 87
-# https://books.google.com/books?id=Das-AQAAIAAJ&pg=PA87
-# These regulations abolished DST and changed the time to GMT+0:30.
-#
-# Defence (Revocation) (No.4) Regulations, 1945 (Regulations No. 45 of
-# 1945) [1945-10-24, commenced on 1946-01-06]
-# Annual Volume of the Laws of the Gold Coast:
-# Containing All Legislation Enacted During Year 1945, p 256
-# https://books.google.com/books?id=9as-AQAAIAAJ&pg=PA256
-# These regulations revoked the previous two sets of Regulations.
-#
-# Time Determination (Amendment) Ordinance, 1945 (No. 18 of 1945) [1946-01-06]
-# Annual Volume of the Laws of the Gold Coast:
-# Containing All Legislation Enacted During Year 1945, p 69
-# https://books.google.com/books?id=9as-AQAAIAAJ&pg=PA69
-# This Ordinance abolished DST.
-#
-# Time Determination (Amendment) Ordinance, 1950 (No. 26 of 1950) [1950-07-22]
-# Annual Volume of the Laws of the Gold Coast:
-# Containing All Legislation Enacted During Year 1950, p 35
-# https://books.google.com/books?id=e60-AQAAIAAJ&pg=PA35
-# This Ordinance restored DST but with thirty minutes offset.
-#
-# Time Determination Ordinance (Cap. 264)
-# The Laws of the Gold Coast, Vol. V (1954), p 380
-# https://books.google.com/books?id=Mqc-AQAAIAAJ&pg=PA380
-# Revised edition of the Time Determination Ordinance.
-#
-# Time Determination (Amendment) Ordinance, 1956 (No. 21 of 1956) [1956-08-29]
-# Annual Volume of the Ordinances of the Gold Coast Enacted During the
-# Year 1956, p 83
-# https://books.google.com/books?id=VLE-AQAAIAAJ&pg=PA83
-# This Ordinance abolished DST.
-
-# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Ghana	1919	only	-	Nov	24	0:00	0:20	+0020
-Rule	Ghana	1920	1942	-	Jan	 1	2:00	0	GMT
-Rule	Ghana	1920	1939	-	Sep	 1	2:00	0:20	+0020
-Rule	Ghana	1940	1941	-	May	 1	2:00	0:20	+0020
-Rule	Ghana	1950	1955	-	Sep	 1	2:00	0:30	+0030
-Rule	Ghana	1951	1956	-	Jan	 1	2:00	0	GMT
-
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Accra	-0:00:52 -	LMT	1915 Nov  2
-			 0:00	Ghana	%s	1942 Feb  8
-			 0:30	-	+0030	1946 Jan  6
-			 0:00	Ghana	%s
-
 # Guinea
 # See Africa/Abidjan.
 
@@ -755,7 +668,7 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 # See Africa/Nairobi.
 
 # Morocco
-# See the 'europe' file for Spanish Morocco (Africa/Ceuta).
+# See Africa/Ceuta for Spanish Morocco.
 
 # From Alex Krivenyshev (2008-05-09):
 # Here is an article that Morocco plan to introduce Daylight Saving Time between
@@ -1405,22 +1318,20 @@ Zone	Africa/Lagos	0:13:35 -	LMT	1905 Jul  1
 			0:13:35	-	LMT	1914 Jan  1
 			0:30	-	+0030	1919 Sep  1
 			1:00	-	WAT
-Link Africa/Lagos Africa/Bangui	     # Central African Republic
-Link Africa/Lagos Africa/Brazzaville # Rep. of the Congo
-Link Africa/Lagos Africa/Douala	     # Cameroon
-Link Africa/Lagos Africa/Kinshasa    # Dem. Rep. of the Congo (west)
-Link Africa/Lagos Africa/Libreville  # Gabon
-Link Africa/Lagos Africa/Luanda	     # Angola
-Link Africa/Lagos Africa/Malabo	     # Equatorial Guinea
-Link Africa/Lagos Africa/Niamey	     # Niger
-Link Africa/Lagos Africa/Porto-Novo  # Benin
+Link Africa/Lagos Africa/Bangui		# Central African Republic
+Link Africa/Lagos Africa/Brazzaville	# Rep. of the Congo
+Link Africa/Lagos Africa/Douala		# Cameroon
+Link Africa/Lagos Africa/Kinshasa	# Dem. Rep. of the Congo (west)
+Link Africa/Lagos Africa/Libreville	# Gabon
+Link Africa/Lagos Africa/Luanda		# Angola
+Link Africa/Lagos Africa/Malabo		# Equatorial Guinea
+Link Africa/Lagos Africa/Niamey		# Niger
+Link Africa/Lagos Africa/Porto-Novo	# Benin
 
 # Réunion
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Indian/Reunion	3:41:52 -	LMT	1911 Jun # Saint-Denis
 			4:00	-	+04
-#
-# Crozet Islands also observes Réunion time; see the 'antarctica' file.
 #
 # Scattered Islands (Îles Éparses) administered from Réunion are as follows.
 # The following information about them is taken from
@@ -1513,8 +1424,8 @@ Rule	SA	1943	1944	-	Mar	Sun>=15	2:00	0	-
 Zone Africa/Johannesburg 1:52:00 -	LMT	1892 Feb 8
 			1:30	-	SAST	1903 Mar
 			2:00	SA	SAST
-Link Africa/Johannesburg Africa/Maseru	   # Lesotho
-Link Africa/Johannesburg Africa/Mbabane    # Eswatini
+Link Africa/Johannesburg Africa/Maseru	# Lesotho
+Link Africa/Johannesburg Africa/Mbabane	# Eswatini
 #
 # Marion and Prince Edward Is
 # scientific station since 1947
@@ -1550,12 +1461,13 @@ Zone	Africa/Khartoum	2:10:08 -	LMT	1931
 			3:00	-	EAT	2017 Nov  1
 			2:00	-	CAT
 
+# South Sudan
+
 # From Steffen Thorsen (2021-01-18):
 # "South Sudan will change its time zone by setting the clock back 1
 # hour on February 1, 2021...."
 # from https://eyeradio.org/south-sudan-adopts-new-time-zone-makuei/
 
-# South Sudan
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Juba	2:06:28 -	LMT	1931
 			2:00	Sudan	CA%sT	2000 Jan 15 12:00
@@ -1660,7 +1572,7 @@ Rule	Tunisia	2005	only	-	Sep	30	 1:00s	0	-
 Rule	Tunisia	2006	2008	-	Mar	lastSun	 2:00s	1:00	S
 Rule	Tunisia	2006	2008	-	Oct	lastSun	 2:00s	0	-
 
-# See Europe/Paris for PMT-related transitions.
+# See Europe/Paris commentary for PMT-related transitions.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Tunis	0:40:44 -	LMT	1881 May 12
 			0:09:21	-	PMT	1911 Mar 11 # Paris Mean Time

--- a/make/data/tzdata/antarctica
+++ b/make/data/tzdata/antarctica
@@ -171,7 +171,7 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 #
 # Alfred Faure, Possession Island, Crozet Islands, -462551+0515152, since 1964;
 #	sealing & whaling stations operated variously 1802/1911+;
-#	see Indian/Reunion.
+#	see Asia/Dubai.
 #
 # Martin-de-Viviès, Amsterdam Island, -374105+0773155, since 1950
 # Port-aux-Français, Kerguelen Islands, -492110+0701303, since 1951;
@@ -185,17 +185,7 @@ Zone Indian/Kerguelen	0	-	-00	1950 # Port-aux-Français
 			5:00	-	+05
 #
 # year-round base in the main continent
-# Dumont d'Urville, Île des Pétrels, -6640+14001, since 1956-11
-# <https://en.wikipedia.org/wiki/Dumont_d'Urville_Station> (2005-12-05)
-#
-# Another base at Port-Martin, 50km east, began operation in 1947.
-# It was destroyed by fire on 1952-01-14.
-#
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Antarctica/DumontDUrville 0 -	-00	1947
-			10:00	-	+10	1952 Jan 14
-			0	-	-00	1956 Nov
-			10:00	-	+10
+# Dumont d'Urville - see Pacific/Port_Moresby.
 
 # France & Italy - year-round base
 # Concordia, -750600+1232000, since 2005
@@ -211,20 +201,7 @@ Zone Antarctica/DumontDUrville 0 -	-00	1947
 # Zuchelli, Terra Nova Bay, -744140+1640647, since 1986
 
 # Japan - year-round bases
-# Syowa (also known as Showa), -690022+0393524, since 1957
-#
-# From Hideyuki Suzuki (1999-02-06):
-# In all Japanese stations, +0300 is used as the standard time.
-#
-# Syowa station, which is the first antarctic station of Japan,
-# was established on 1957-01-29.  Since Syowa station is still the main
-# station of Japan, it's appropriate for the principal location.
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Antarctica/Syowa	0	-	-00	1957 Jan 29
-			3:00	-	+03
-# See:
-# NIPR Antarctic Research Activities (1999-08-17)
-# http://www.nipr.ac.jp/english/ara01.html
+# See Asia/Riyadh.
 
 # S Korea - year-round base
 # Jang Bogo, Terra Nova Bay, -743700+1641205 since 2014

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -57,9 +57,6 @@
 # Byalokoz EL. New Counting of Time in Russia since July 1, 1919.
 # (See the 'europe' file for a fuller citation.)
 #
-# A reliable and entertaining source about time zones is
-# Derek Howse, Greenwich time and longitude, Philip Wilson Publishers (1997).
-#
 # The following alphabetic abbreviations appear in these tables
 # (corrections are welcome):
 #	     std  dst
@@ -2257,6 +2254,14 @@ Zone	Asia/Tokyo	9:18:59	-	LMT	1887 Dec 31 15:00u
 # From Paul Eggert (2013-12-11):
 # As Steffen suggested, consider the past 21-month experiment to be DST.
 
+# From Steffen Thorsen (2021-09-24):
+# The Jordanian Government announced yesterday that they will start DST
+# in February instead of March:
+# https://petra.gov.jo/Include/InnerPage.jsp?ID=37683&lang=en&name=en_news (English)
+# https://petra.gov.jo/Include/InnerPage.jsp?ID=189969&lang=ar&name=news (Arabic)
+# From the Arabic version, it seems to say it would be at midnight
+# (assume 24:00) on the last Thursday in February, starting from 2022.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Jordan	1973	only	-	Jun	6	0:00	1:00	S
 Rule	Jordan	1973	1975	-	Oct	1	0:00	0	-
@@ -2287,8 +2292,9 @@ Rule	Jordan	2004	only	-	Oct	15	0:00s	0	-
 Rule	Jordan	2005	only	-	Sep	lastFri	0:00s	0	-
 Rule	Jordan	2006	2011	-	Oct	lastFri	0:00s	0	-
 Rule	Jordan	2013	only	-	Dec	20	0:00	0	-
-Rule	Jordan	2014	max	-	Mar	lastThu	24:00	1:00	S
+Rule	Jordan	2014	2021	-	Mar	lastThu	24:00	1:00	S
 Rule	Jordan	2014	max	-	Oct	lastFri	0:00s	0	-
+Rule	Jordan	2022	max	-	Feb	lastThu	24:00	1:00	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Amman	2:23:44 -	LMT	1931
 			2:00	Jordan	EE%sT
@@ -2763,7 +2769,8 @@ Rule	NBorneo	1935	1941	-	Dec	14	0:00	0	-
 #
 # peninsular Malaysia
 # taken from Mok Ly Yng (2003-10-30)
-# http://www.math.nus.edu.sg/aslaksen/teaching/timezone.html
+# https://web.archive.org/web/20190822231045/http://www.math.nus.edu.sg/~mathelmr/teaching/timezone.html
+# This agrees with Singapore since 1905-06-01.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Asia/Kuala_Lumpur	6:46:46 -	LMT	1901 Jan  1
 			6:55:25	-	SMT	1905 Jun  1 # Singapore M.T.
@@ -3523,6 +3530,12 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 # influence of the sources.  There is no current abbreviation for DST,
 # so use "PDT", the usual American style.
 
+# From P Chan (2021-05-10):
+# Here's a fairly comprehensive article in Japanese:
+# https://wiki.suikawiki.org/n/Philippine%20Time
+# From Paul Eggert (2021-05-10):
+# The info in the Japanese table has not been absorbed (yet) below.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Phil	1936	only	-	Nov	1	0:00	1:00	D
 Rule	Phil	1937	only	-	Feb	1	0:00	0	S
@@ -3589,12 +3602,13 @@ Link Asia/Qatar Asia/Bahrain
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Riyadh	3:06:52 -	LMT	1947 Mar 14
 			3:00	-	+03
+Link Asia/Riyadh Antarctica/Syowa
 Link Asia/Riyadh Asia/Aden	# Yemen
 Link Asia/Riyadh Asia/Kuwait
 
 # Singapore
 # taken from Mok Ly Yng (2003-10-30)
-# http://www.math.nus.edu.sg/aslaksen/teaching/timezone.html
+# https://web.archive.org/web/20190822231045/http://www.math.nus.edu.sg/~mathelmr/teaching/timezone.html
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 			6:55:25	-	SMT	1905 Jun  1 # Singapore M.T.

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -3409,11 +3409,6 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # shall [end] on Oct 24th 2020 at 01:00AM by delaying the clock by 60 minutes.
 # http://www.palestinecabinet.gov.ps/portal/Meeting/Details/51584
 
-# From Tim Parenti (2020-10-20):
-# Predict future fall transitions at 01:00 on the Saturday preceding October's
-# last Sunday (i.e., Sat>=24).  This is consistent with our predictions since
-# 2016, although the time of the change differed slightly in 2019.
-
 # From Pierre Cashon (2020-10-20):
 # The summer time this year started on March 28 at 00:00.
 # https://wafa.ps/ar_page.aspx?id=GveQNZa872839351758aGveQNZ
@@ -3425,6 +3420,17 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # From Paul Eggert (2019-04-10):
 # For now, guess spring-ahead transitions are at 00:00 on the Saturday
 # preceding March's last Sunday (i.e., Sat>=24).
+
+# From P Chan (2021-10-18):
+# http://wafa.ps/Pages/Details/34701
+# Palestine winter time will start from midnight 2021-10-29 (Thursday-Friday).
+#
+# From Heba Hemad, Palestine Ministry of Telecom & IT (2021-10-20):
+# ... winter time will begin in Palestine from Friday 10-29, 01:00 AM
+# by 60 minutes backwards.
+#
+# From Paul Eggert (2021-10-20):
+# Guess future fall transitions on October's last Friday at 01:00.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule EgyptAsia	1957	only	-	May	10	0:00	1:00	S
@@ -3461,7 +3467,8 @@ Rule Palestine	2016	2018	-	Oct	Sat>=24	1:00	0	-
 Rule Palestine	2019	only	-	Mar	29	0:00	1:00	S
 Rule Palestine	2019	only	-	Oct	Sat>=24	0:00	0	-
 Rule Palestine	2020	max	-	Mar	Sat>=24	0:00	1:00	S
-Rule Palestine	2020	max	-	Oct	Sat>=24	1:00	0	-
+Rule Palestine	2020	only	-	Oct	24	1:00	0	-
+Rule Palestine	2021	max	-	Oct	lastFri	1:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -408,9 +408,22 @@ Zone	Indian/Cocos	6:27:40	-	LMT	1900
 # "Minister for Employment, Parveen Bala says they had never thought of
 # stopping daylight saving. He says it was just to decide on when it should
 # start and end.  Bala says it is a short period..."
-# Since the end date is still in line with our ongoing predictions, assume for
-# now that the later-than-usual start date is a one-time departure from the
-# recent second Sunday in November pattern.
+#
+# From Tim Parenti (2021-10-11), per Jashneel Kumar (2021-10-11) and P Chan
+# (2021-10-12):
+# https://www.fiji.gov.fj/Media-Centre/Speeches/English/PM-BAINIMARAMA-S-COVID-19-ANNOUNCEMENT-10-10-21
+# https://www.fbcnews.com.fj/news/covid-19/curfew-moved-back-to-11pm/
+# In a 2021-10-10 speech concerning updated Covid-19 mitigation measures in
+# Fiji, prime minister Josaia Voreqe "Frank" Bainimarama announced the
+# suspension of DST for the 2021/2022 season: "Given that we are in the process
+# of readjusting in the midst of so many changes, we will also put Daylight
+# Savings Time on hold for this year. It will also make the reopening of
+# scheduled commercial air service much smoother if we don't have to be
+# concerned shifting arrival and departure times, which may look like a simple
+# thing but requires some significant logistical adjustments domestically and
+# internationally."
+# Assume for now that DST will resume with the recent pre-2020 rules for the
+# 2022/2023 season.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Fiji	1998	1999	-	Nov	Sun>=1	2:00	1:00	-
@@ -422,10 +435,11 @@ Rule	Fiji	2011	only	-	Mar	Sun>=1	3:00	0	-
 Rule	Fiji	2012	2013	-	Jan	Sun>=18	3:00	0	-
 Rule	Fiji	2014	only	-	Jan	Sun>=18	2:00	0	-
 Rule	Fiji	2014	2018	-	Nov	Sun>=1	2:00	1:00	-
-Rule	Fiji	2015	max	-	Jan	Sun>=12	3:00	0	-
+Rule	Fiji	2015	2021	-	Jan	Sun>=12	3:00	0	-
 Rule	Fiji	2019	only	-	Nov	Sun>=8	2:00	1:00	-
 Rule	Fiji	2020	only	-	Dec	20	2:00	1:00	-
-Rule	Fiji	2021	max	-	Nov	Sun>=8	2:00	1:00	-
+Rule	Fiji	2022	max	-	Nov	Sun>=8	2:00	1:00	-
+Rule	Fiji	2023	max	-	Jan	Sun>=12	3:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
 			12:00	Fiji	+12/+13

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -487,7 +487,7 @@ Link Pacific/Guam Pacific/Saipan # N Mariana Is
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Tarawa	 11:32:04 -	LMT	1901 # Bairiki
 			 12:00	-	+12
-Zone Pacific/Enderbury	-11:24:20 -	LMT	1901
+Zone Pacific/Kanton	  0	-	-00	1937 Aug 31
 			-12:00	-	-12	1979 Oct
 			-11:00	-	-11	1994 Dec 31
 			 13:00	-	+13
@@ -620,13 +620,46 @@ Link Pacific/Auckland Antarctica/McMurdo
 # was probably like Pacific/Auckland
 
 # Cook Is
-# From Shanks & Pottenger:
+#
+# From Alexander Krivenyshev (2021-03-24):
+# In 1899 the Cook Islands celebrated Christmas twice to correct the calendar.
+# According to the old books, missionaries were unaware of
+# the International Date line, when they came from Sydney.
+# Thus the Cook Islands were one day ahead....
+# http://nzetc.victoria.ac.nz/tm/scholarly/tei-KloDisc-t1-body-d18.html
+# ... Appendix to the Journals of the House of Representatives, 1900
+# https://atojs.natlib.govt.nz/cgi-bin/atojs?a=d&d=AJHR1900-I.2.1.2.3
+# (page 20)
+#
+# From Michael Deckers (2021-03-24):
+# ... in the Cook Island Act of 1915-10-11, online at
+# http://www.paclii.org/ck/legis/ck-nz_act/cia1915132/
+# "651. The hour of the day shall in each of the islands included in the
+#  Cook Islands be determined in accordance with the meridian of that island."
+# so that local (mean?) time was still used in Rarotonga (and Niue) in 1915.
+# This was changed in the Cook Island Amendment Act of 1952-10-16 ...
+# http://www.paclii.org/ck/legis/ck-nz_act/ciaa1952212/
+# "651 (1) The hour of the day in each of the islands included in the Cook
+#  Islands, other than Niue, shall be determined as if each island were
+#  situated on the meridian one hundred and fifty-seven degrees thirty minutes
+#  West of Greenwich.  (2) The hour of the day in the Island of Niue shall be
+#  determined as if that island were situated on the meridian one hundred and
+#  seventy degrees West of Greenwich."
+# This act does not state when it takes effect, so one has to assume it
+# applies since 1952-10-16.  But there is the possibility that the act just
+# legalized prior existing practice, as we had seen with the Guernsey law of
+# 1913-06-18 for the switch in 1909-04-19.
+#
+# From Paul Eggert (2021-03-24):
+# Transitions after 1952 are from Shanks & Pottenger.
+#
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Cook	1978	only	-	Nov	12	0:00	0:30	-
 Rule	Cook	1979	1991	-	Mar	Sun>=1	0:00	0	-
 Rule	Cook	1979	1990	-	Oct	lastSun	0:00	0:30	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Rarotonga	-10:39:04 -	LMT	1901        # Avarua
+Zone Pacific/Rarotonga	13:20:56 -	LMT	1899 Dec 26 # Avarua
+			-10:39:04 -	LMT	1952 Oct 16
 			-10:30	-	-1030	1978 Nov 12
 			-10:00	Cook	-10/-0930
 
@@ -634,10 +667,18 @@ Zone Pacific/Rarotonga	-10:39:04 -	LMT	1901        # Avarua
 
 
 # Niue
+# See Pacific/Raratonga comments for 1952 transition.
+#
+# From Tim Parenti (2021-09-13):
+# Consecutive contemporaneous editions of The Air Almanac listed -11:20 for
+# Niue as of Apr 1964 but -11 as of Aug 1964:
+#   Apr 1964: https://books.google.com/books?id=_1So677Y5vUC&pg=SL1-PA23
+#   Aug 1964: https://books.google.com/books?id=MbJloqd-zyUC&pg=SL1-PA23
+# Without greater specificity, guess 1964-07-01 for this transition.
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Niue	-11:19:40 -	LMT	1901        # Alofi
-			-11:20	-	-1120	1951
-			-11:30	-	-1130	1978 Oct  1
+Zone	Pacific/Niue	-11:19:40 -	LMT	1952 Oct 16	# Alofi
+			-11:20	-	-1120	1964 Jul
 			-11:00	-	-11
 
 # Norfolk
@@ -661,6 +702,7 @@ Zone Pacific/Palau	-15:02:04 -	LMT	1844 Dec 31	# Koror
 Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 			9:48:32	-	PMMT	1895 # Port Moresby Mean Time
 			10:00	-	+10
+Link Pacific/Port_Moresby Antarctica/DumontDUrville
 #
 # From Paul Eggert (2014-10-13):
 # Base the Bougainville entry on the Arawa-Kieta region, which appears to have
@@ -765,13 +807,17 @@ Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
 # From Paul Eggert (2014-07-08):
 # That web page currently lists transitions for 2012/3 and 2013/4.
 # Assume the pattern instituted in 2012 will continue indefinitely.
+#
+# From Geoffrey D. Bennett (2021-09-20):
+# https://www.mcil.gov.ws/storage/2021/09/MCIL-Scan_20210920_120553.pdf
+# DST has been cancelled for this year.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	WS	2010	only	-	Sep	lastSun	0:00	1	-
 Rule	WS	2011	only	-	Apr	Sat>=1	4:00	0	-
 Rule	WS	2011	only	-	Sep	lastSat	3:00	1	-
-Rule	WS	2012	max	-	Apr	Sun>=1	4:00	0	-
-Rule	WS	2012	max	-	Sep	lastSun	3:00	1	-
+Rule	WS	2012	2021	-	Apr	Sun>=1	4:00	0	-
+Rule	WS	2012	2020	-	Sep	lastSun	3:00	1	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Apia	 12:33:04 -	LMT	1892 Jul  5
 			-11:26:56 -	LMT	1911
@@ -818,8 +864,8 @@ Rule	Tonga	2001	2002	-	Jan	lastSun	2:00	0	-
 Rule	Tonga	2016	only	-	Nov	Sun>=1	2:00	1:00	-
 Rule	Tonga	2017	only	-	Jan	Sun>=15	3:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Tongatapu	12:19:20 -	LMT	1901
-			12:20	-	+1220	1941
+Zone Pacific/Tongatapu	12:19:12 -	LMT	1945 Sep 10
+			12:20	-	+1220	1961
 			13:00	-	+13	1999
 			13:00	Tonga	+13/+14
 
@@ -1761,6 +1807,23 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # One source for this is page 202 of: Bartky IR. One Time Fits All:
 # The Campaigns for Global Uniformity (2007).
 
+# Kanton
+
+# From Paul Eggert (2021-05-27):
+# Kiribati's +13 timezone is represented by Kanton, its only populated
+# island.  (It was formerly spelled "Canton", but Gilbertese lacks "C".)
+# Kanton was settled on 1937-08-31 by two British radio operators
+# <https://history.state.gov/historicaldocuments/frus1937v02/d94>;
+# Americans came the next year and built an airfield, partly to
+# establish airline service and perhaps partly anticipating the
+# next war.  Aside from the war, the airfield was used by commercial
+# airlines until long-range jets became standard; although currently
+# for emergency use only, China says it is considering rebuilding the
+# airfield for high-end niche tourism.  Kanton has about two dozen
+# people, caretakers who rotate in from the rest of Kiribati in 2-5
+# year shifts, and who use some of the leftover structures
+# <http://pipa.neaq.org/2012/06/images-of-kanton-island.html>.
+
 # Kwajalein
 
 # From an AP article (1993-08-22):
@@ -2044,6 +2107,17 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 
 # Tonga
 
+# From Paul Eggert (2021-03-04):
+# In 1943 "The standard time kept is 12 hrs. 19 min. 12 sec. fast
+# on Greenwich mean time." according to the Admiralty's Hydrographic
+# Dept., Pacific Islands Pilot, Vol. II, 7th ed., 1943, p 360.
+
+# From Michael Deckers (2021-03-03):
+# [Ian R Bartky: "One Time Fits All: The Campaigns for Global Uniformity".
+# Stanford University Press. 2007. p. 255]:
+# On 10 September 1945 Tonga adopted a standard time 12 hours,
+# 20 minutes in advance of Greenwich.
+
 # From Paul Eggert (1996-01-22):
 # Today's _Wall Street Journal_ (p 1) reports that "Tonga has been plotting
 # to sneak ahead of [New Zealanders] by introducing daylight-saving time."
@@ -2072,9 +2146,26 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # The Crown Prince, presented an unanswerable argument: "Remember that
 # on the World Day of Prayer, you would be the first people on Earth
 # to say your prayers in the morning."
-
-# From Paul Eggert (2006-03-22):
-# Shanks & Pottenger say the transition was on 1968-10-01; go with Mundell.
+#
+# From Tim Parenti (2021-09-13), per Paul Eggert (2006-03-22) and Michael
+# Deckers (2021-03-03):
+# Mundell places the transition from +12:20 to +13 in 1941, while Shanks &
+# Pottenger say the transition was on 1968-10-01.
+#
+# The Air Almanac published contemporaneous tables of standard times,
+# which listed +12:20 as of Nov 1960 and +13 as of Mar 1961:
+#   Nov 1960: https://books.google.com/books?id=bVgtWM6kPZUC&pg=SL1-PA19
+#   Mar 1961: https://books.google.com/books?id=W2nItAul4g0C&pg=SL1-PA19
+# (Thanks to P Chan for pointing us toward these sources.)
+# This agrees with Bartky, who writes that "since 1961 [Tonga's] official time
+# has been thirteen hours in advance of Greenwich time" (p. 202) and further
+# writes in an endnote that this was because "the legislation was amended" on
+# 1960-10-19. (p. 255)
+#
+# Without greater specificity, presume that Bartky and the Air Almanac point to
+# a 1961-01-01 transition, as Tāufaʻāhau Tupou IV was still Crown Prince in
+# 1961 and this still jives with the gist of Mundell's telling, and go with
+# this over Shanks & Pottenger.
 
 # From Eric Ulevik (1999-05-03):
 # Tonga's director of tourism, who is also secretary of the National Millennium

--- a/make/data/tzdata/backward
+++ b/make/data/tzdata/backward
@@ -26,8 +26,10 @@
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
-# This file provides links between current names for timezones
-# and their old names.  Many names changed in late 1993.
+# This file provides links from old or merged timezone names to current ones.
+# Many names changed in late 1993.  Several of these names are
+# also present in the file 'backzone', which has data important only
+# for pre-1970 timestamps and so is out of scope for tzdb proper.
 
 # Link	TARGET			LINK-NAME
 Link	Africa/Nairobi		Africa/Asmera
@@ -36,7 +38,7 @@ Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
 Link	America/Adak		America/Atka
 Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
 Link	America/Argentina/Catamarca	America/Catamarca
-Link	America/Atikokan	America/Coral_Harbour
+Link	America/Panama		America/Coral_Harbour
 Link	America/Argentina/Cordoba	America/Cordoba
 Link	America/Tijuana		America/Ensenada
 Link	America/Indiana/Indianapolis	America/Fort_Wayne
@@ -51,7 +53,7 @@ Link	America/Rio_Branco	America/Porto_Acre
 Link	America/Argentina/Cordoba	America/Rosario
 Link	America/Tijuana		America/Santa_Isabel
 Link	America/Denver		America/Shiprock
-Link	America/Port_of_Spain	America/Virgin
+Link	America/Puerto_Rico	America/Virgin
 Link	Pacific/Auckland	Antarctica/South_Pole
 Link	Asia/Ashgabat		Asia/Ashkhabad
 Link	Asia/Kolkata		Asia/Calcutta
@@ -126,6 +128,7 @@ Link	Pacific/Auckland	NZ
 Link	Pacific/Chatham		NZ-CHAT
 Link	America/Denver		Navajo
 Link	Asia/Shanghai		PRC
+Link	Pacific/Kanton		Pacific/Enderbury
 Link	Pacific/Honolulu	Pacific/Johnston
 Link	Pacific/Pohnpei		Pacific/Ponape
 Link	Pacific/Pago_Pago	Pacific/Samoa

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -844,7 +844,7 @@ Zone	Europe/Andorra	0:06:04 -	LMT	1901
 # Shanks & Pottenger give 02:00, the BEV 00:00.  Go with the BEV,
 # and guess 02:00 for 1945-04-12.
 
-# From Alois Triendl (2019-07-22):
+# From Alois Treindl (2019-07-22):
 # In 1946 the end of DST was on Monday, 7 October 1946, at 3:00 am.
 # Shanks had this right.  Source: Die Weltpresse, 5. Oktober 1946, page 5.
 
@@ -1758,19 +1758,22 @@ Zone Atlantic/Reykjavik	-1:28	-	LMT	1908
 # advanced to sixty minutes later starting at hour two on 1944-04-02; ...
 # Starting at hour three on the date 1944-09-17 standard time will be resumed.
 #
-# From Alois Triendl (2019-07-02):
+# From Alois Treindl (2019-07-02):
 # I spent 6 Euros to buy two archive copies of Il Messaggero, a Roman paper,
 # for 1 and 2 April 1944.  The edition of 2 April has this note: "Tonight at 2
 # am, put forward the clock by one hour.  Remember that in the night between
 # today and Monday the 'ora legale' will come in force again."  That makes it
 # clear that in Rome the change was on Monday, 3 April 1944 at 2 am.
 #
-# From Paul Eggert (2016-10-27):
+# From Paul Eggert (2021-10-05):
 # Go with INRiM for DST rules, except as corrected by Inglis for 1944
 # for the Kingdom of Italy.  This is consistent with Renzo Baldini.
 # Model Rome's occupation by using C-Eur rules from 1943-09-10
 # to 1944-06-04; although Rome was an open city during this period, it
-# was effectively controlled by Germany.
+# was effectively controlled by Germany.  Using C-Eur is consistent
+# with Treindl's comment about Rome in April 1944, as the "Rule Italy"
+# lines during German occupation do not affect Europe/Rome
+# (though they do affect Europe/Malta).
 #
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Italy	1916	only	-	Jun	 3	24:00	1:00	S
@@ -2646,7 +2649,7 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # Although Shanks lists 1945-01-01 as the date for transition from
 # +01/+02 to +02/+03, more likely this is a placeholder.  Guess that
 # the transition occurred at 1945-04-10 00:00, which is about when
-# Königsberg surrendered to Soviet troops.  (Thanks to Alois Triendl.)
+# Königsberg surrendered to Soviet troops.  (Thanks to Alois Treindl.)
 
 # From Paul Eggert (2016-03-18):
 # The 1989 transition is from USSR act No. 227 (1989-03-14).

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -91,7 +91,6 @@
 #        0:00       GMT  BST  BDST  Greenwich, British Summer
 #        0:00       GMT  IST        Greenwich, Irish Summer
 #        0:00       WET  WEST WEMT  Western Europe
-#        0:19:32.13 AMT* NST*       Amsterdam, Netherlands Summer (1835-1937)
 #        1:00       BST             British Standard (1968-1971)
 #        1:00       IST  GMT        Irish Standard (1968-) with winter DST
 #        1:00       CET  CEST CEMT  Central Europe
@@ -1823,6 +1822,10 @@ Zone	Europe/Rome	0:49:56 -	LMT	1866 Dec 12
 			1:00	Italy	CE%sT	1980
 			1:00	EU	CE%sT
 
+# Kosovo
+# See Europe/Belgrade.
+
+
 Link	Europe/Rome	Europe/Vatican
 Link	Europe/Rome	Europe/San_Marino
 
@@ -2173,6 +2176,10 @@ Zone	Europe/Monaco	0:29:32 -	LMT	1892 Jun  1
 # The data entries before 1945 are taken from
 # https://www.staff.science.uu.nl/~gent0113/wettijd/wettijd.htm
 
+# From Paul Eggert (2021-05-09):
+# I invented the abbreviations AMT for Amsterdam Mean Time and NST for
+# Netherlands Summer Time, used in the Netherlands from 1835 to 1937.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Neth	1916	only	-	May	 1	0:00	1:00	NST	# Netherlands Summer Time
 Rule	Neth	1916	only	-	Oct	 1	0:00	0	AMT	# Amsterdam Mean Time
@@ -2399,12 +2406,10 @@ Rule	Port	1943	1945	-	Aug	Sat>=25	22:00s	1:00	S
 Rule	Port	1944	1945	-	Apr	Sat>=21	22:00s	2:00	M
 Rule	Port	1946	only	-	Apr	Sat>=1	23:00s	1:00	S
 Rule	Port	1946	only	-	Oct	Sat>=1	23:00s	0	-
-Rule	Port	1947	1949	-	Apr	Sun>=1	 2:00s	1:00	S
-Rule	Port	1947	1949	-	Oct	Sun>=1	 2:00s	0	-
-# Shanks & Pottenger say DST was observed in 1950; go with Whitman.
+# Whitman says DST was not observed in 1950; go with Shanks & Pottenger.
 # Whitman gives Oct lastSun for 1952 on; go with Shanks & Pottenger.
-Rule	Port	1951	1965	-	Apr	Sun>=1	 2:00s	1:00	S
-Rule	Port	1951	1965	-	Oct	Sun>=1	 2:00s	0	-
+Rule	Port	1947	1965	-	Apr	Sun>=1	 2:00s	1:00	S
+Rule	Port	1947	1965	-	Oct	Sun>=1	 2:00s	0	-
 Rule	Port	1977	only	-	Mar	27	 0:00s	1:00	S
 Rule	Port	1977	only	-	Sep	25	 0:00s	0	-
 Rule	Port	1978	1979	-	Apr	Sun>=1	 0:00s	1:00	S
@@ -3705,6 +3710,9 @@ Zone	Atlantic/Canary	-1:01:36 -	LMT	1922 Mar # Las Palmas de Gran C.
 # hour before the event took place.
 #
 # Source: The newspaper "Dagens Nyheter", 1916-10-01, page 7 upper left.
+
+# An extra-special abbreviation style is SET for Swedish Time (svensk
+# normaltid) 1879-1899, 3° west of the Stockholm Observatory.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Europe/Stockholm	1:12:12 -	LMT	1879 Jan  1

--- a/make/data/tzdata/leapseconds
+++ b/make/data/tzdata/leapseconds
@@ -95,11 +95,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2021	Dec	28	00:00:00
+#Expires 2022	Jun	28	00:00:00
 
 # POSIX timestamps for the data in this file:
 #updated 1467936000 (2016-07-08 00:00:00 UTC)
-#expires 1640649600 (2021-12-28 00:00:00 UTC)
+#expires 1656374400 (2022-06-28 00:00:00 UTC)
 
-#	Updated through IERS Bulletin C61
-#	File expires on:  28 December 2021
+#	Updated through IERS Bulletin C62
+#	File expires on:  28 June 2022

--- a/make/data/tzdata/northamerica
+++ b/make/data/tzdata/northamerica
@@ -999,7 +999,7 @@ Zone America/Indiana/Vincennes -5:50:07 - LMT	1883 Nov 18 12:09:53
 			-5:00	US	E%sT
 #
 # Perry County, Indiana, switched from eastern to central time in April 2006.
-# From Alois Triendl (2019-07-09):
+# From Alois Treindl (2019-07-09):
 # The Indianapolis News, Friday 27 October 1967 states that Perry County
 # returned to CST.  It went again to EST on 27 April 1969, as documented by the
 # Indianapolis star of Saturday 26 April.
@@ -1959,7 +1959,7 @@ Zone America/Swift_Current -7:11:20 -	LMT	1905 Sep
 
 # Alberta
 
-# From Alois Triendl (2019-07-19):
+# From Alois Treindl (2019-07-19):
 # There was no DST in Alberta in 1967... Calgary Herald, 29 April 1967.
 # 1969, no DST, from Edmonton Journal 18 April 1969
 #
@@ -2014,7 +2014,7 @@ Zone America/Edmonton	-7:33:52 -	LMT	1906 Sep
 #
 # From Paul Eggert (2019-07-25):
 # Shanks says Fort Nelson did not observe DST in 1946, unlike Vancouver.
-# Alois Triendl confirmed this on 07-22, citing the 1946-04-27 Vancouver Daily
+# Alois Treindl confirmed this on 07-22, citing the 1946-04-27 Vancouver Daily
 # Province.  He also cited the 1946-09-28 Victoria Daily Times, which said
 # that Vancouver, Victoria, etc. "change at midnight Saturday"; for now,
 # guess they meant 02:00 Sunday since 02:00 was common practice in Vancouver.

--- a/make/data/tzdata/northamerica
+++ b/make/data/tzdata/northamerica
@@ -752,7 +752,11 @@ Zone America/Adak	 12:13:22 -	LMT	1867 Oct 19 12:44:35
 			-11:00	US	B%sT	1983 Oct 30  2:00
 			-10:00	US	AH%sT	1983 Nov 30
 			-10:00	US	H%sT
-# The following switches don't quite make our 1970 cutoff.
+# The following switches don't make our 1970 cutoff.
+#
+# Kiska observed Tokyo date and time during Japanese occupation from
+# 1942-06-06 to 1943-07-29, and similarly for Attu from 1942-06-07 to
+# 1943-05-29 (all dates American).  Both islands are now uninhabited.
 #
 # Shanks writes that part of southwest Alaska (e.g. Aniak)
 # switched from -11:00 to -10:00 on 1968-09-22 at 02:00,
@@ -848,6 +852,8 @@ Zone America/Phoenix	-7:28:18 -	LMT	1883 Nov 18 11:31:42
 			-7:00	-	MST	1967
 			-7:00	US	M%sT	1968 Mar 21
 			-7:00	-	MST
+Link America/Phoenix America/Creston
+
 # From Arthur David Olson (1988-02-13):
 # A writer from the Inter Tribal Council of Arizona, Inc.,
 # notes in private correspondence dated 1987-12-28 that "Presently, only the
@@ -1616,24 +1622,7 @@ Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 # From Paul Eggert (2020-01-10):
 # See America/Toronto for most of Quebec, including Montreal.
 # See America/Halifax for the Îles de la Madeleine and the Listuguj reserve.
-#
-# Matthews and Vincent (1998) also write that Quebec east of the -63
-# meridian is supposed to observe AST, but residents as far east as
-# Natashquan use EST/EDT, and residents east of Natashquan use AST.
-# The Quebec department of justice writes in
-# "The situation in Minganie and Basse-Côte-Nord"
-# https://www.justice.gouv.qc.ca/en/department/ministre/functions-and-responsabilities/legal-time-in-quebec/the-situation-in-minganie-and-basse-cote-nord/
-# that the coastal strip from just east of Natashquan to Blanc-Sablon
-# observes Atlantic standard time all year round.
-# This common practice was codified into law as of 2007; see Legal Time Act,
-# CQLR c T-5.1 <http://legisquebec.gouv.qc.ca/en/ShowDoc/cs/T-5.1>.
-# For lack of better info, guess this practice began around 1970, contra to
-# Shanks & Pottenger who have this region observing AST/ADT.
-
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Blanc-Sablon -3:48:28 -	LMT	1884
-			-4:00	Canada	A%sT	1970
-			-4:00	-	AST
+# See America/Puerto_Rico for east of Natashquan.
 
 # Ontario
 
@@ -1671,54 +1660,6 @@ Zone America/Blanc-Sablon -3:48:28 -	LMT	1884
 # For more on Orillia, see: Daubs K. Bold attempt at daylight saving
 # time became a comic failure in Orillia. Toronto Star 2017-07-08.
 # https://www.thestar.com/news/insight/2017/07/08/bold-attempt-at-daylight-saving-time-became-a-comic-failure-in-orillia.html
-
-# From Paul Eggert (1997-10-17):
-# Mark Brader writes that an article in the 1997-10-14 Toronto Star
-# says that Atikokan, Ontario currently does not observe DST,
-# but will vote on 11-10 whether to use EST/EDT.
-# He also writes that the Ontario Time Act (1990, Chapter T.9)
-# http://www.gov.on.ca/MBS/english/publications/statregs/conttext.html
-# says that Ontario east of 90W uses EST/EDT, and west of 90W uses CST/CDT.
-# Officially Atikokan is therefore on CST/CDT, and most likely this report
-# concerns a non-official time observed as a matter of local practice.
-#
-# From Paul Eggert (2000-10-02):
-# Matthews and Vincent (1998) write that Atikokan, Pickle Lake, and
-# New Osnaburgh observe CST all year, that Big Trout Lake observes
-# CST/CDT, and that Upsala and Shebandowan observe EST/EDT, all in
-# violation of the official Ontario rules.
-#
-# From Paul Eggert (2006-07-09):
-# Chris Walton (2006-07-06) mentioned an article by Stephanie MacLellan in the
-# 2005-07-21 Chronicle-Journal, which said:
-#
-#	The clocks in Atikokan stay set on standard time year-round.
-#	This means they spend about half the time on central time and
-#	the other half on eastern time.
-#
-#	For the most part, the system works, Mayor Dennis Brown said.
-#
-#	"The majority of businesses in Atikokan deal more with Eastern
-#	Canada, but there are some that deal with Western Canada," he
-#	said.  "I don't see any changes happening here."
-#
-# Walton also writes "Supposedly Pickle Lake and Mishkeegogamang
-# [New Osnaburgh] follow the same practice."
-
-# From Garry McKinnon (2006-07-14) via Chris Walton:
-# I chatted with a member of my board who has an outstanding memory
-# and a long history in Atikokan (and in the telecom industry) and he
-# can say for certain that Atikokan has been practicing the current
-# time keeping since 1952, at least.
-
-# From Paul Eggert (2006-07-17):
-# Shanks & Pottenger say that Atikokan has agreed with Rainy River
-# ever since standard time was introduced, but the information from
-# McKinnon sounds more authoritative.  For now, assume that Atikokan
-# switched to EST immediately after WWII era daylight saving time
-# ended.  This matches the old (less-populous) America/Coral_Harbour
-# entry since our cutoff date of 1970, so we can move
-# America/Coral_Harbour to the 'backward' file.
 
 # From Mark Brader (2010-03-06):
 #
@@ -1850,6 +1791,7 @@ Zone America/Toronto	-5:17:32 -	LMT	1895
 			-5:00	Canada	E%sT	1946
 			-5:00	Toronto	E%sT	1974
 			-5:00	Canada	E%sT
+Link America/Toronto America/Nassau
 Zone America/Thunder_Bay -5:57:00 -	LMT	1895
 			-6:00	-	CST	1910
 			-5:00	-	EST	1942
@@ -1865,11 +1807,7 @@ Zone America/Rainy_River -6:18:16 -	LMT	1895
 			-6:00	Canada	C%sT	1940 Sep 29
 			-6:00	1:00	CDT	1942 Feb  9  2:00s
 			-6:00	Canada	C%sT
-Zone America/Atikokan	-6:06:28 -	LMT	1895
-			-6:00	Canada	C%sT	1940 Sep 29
-			-6:00	1:00	CDT	1942 Feb  9  2:00s
-			-6:00	Canada	C%sT	1945 Sep 30  2:00
-			-5:00	-	EST
+# For Atikokan see America/Panama.
 
 
 # Manitoba
@@ -2060,60 +1998,6 @@ Zone America/Edmonton	-7:33:52 -	LMT	1906 Sep
 # Shanks & Pottenger write that since 1970 most of this region has
 # been like Vancouver.
 # Dawson Creek uses MST.  Much of east BC is like Edmonton.
-# Matthews and Vincent (1998) write that Creston is like Dawson Creek.
-
-# It seems though that (re: Creston) is not entirely correct:
-
-# From Chris Walton (2011-12-01):
-# There are two areas within the Canadian province of British Columbia
-# that do not currently observe daylight saving:
-# a) The Creston Valley (includes the town of Creston and surrounding area)
-# b) The eastern half of the Peace River Regional District
-# (includes the cities of Dawson Creek and Fort St. John)
-
-# Earlier this year I stumbled across a detailed article about the time
-# keeping history of Creston; it was written by Tammy Hardwick who is the
-# manager of the Creston & District Museum. The article was written in May 2009.
-# http://www.ilovecreston.com/?p=articles&t=spec&ar=260
-# According to the article, Creston has not changed its clocks since June 1918.
-# i.e. Creston has been stuck on UT-7 for 93 years.
-# Dawson Creek, on the other hand, changed its clocks as recently as April 1972.
-
-# Unfortunately the exact date for the time change in June 1918 remains
-# unknown and will be difficult to ascertain.  I e-mailed Tammy a few months
-# ago to ask if Sunday June 2 was a reasonable guess.  She said it was just
-# as plausible as any other date (in June).  She also said that after writing
-# the article she had discovered another time change in 1916; this is the
-# subject of another article which she wrote in October 2010.
-# http://www.creston.museum.bc.ca/index.php?module=comments&uop=view_comment&cm+id=56
-
-# Here is a summary of the three clock change events in Creston's history:
-# 1. 1884 or 1885: adoption of Mountain Standard Time (GMT-7)
-# Exact date unknown
-# 2. Oct 1916: switch to Pacific Standard Time (GMT-8)
-# Exact date in October unknown; Sunday October 1 is a reasonable guess.
-# 3. June 1918: switch to Pacific Daylight Time (GMT-7)
-# Exact date in June unknown; Sunday June 2 is a reasonable guess.
-# note 1:
-# On Oct 27/1918 when daylight saving ended in the rest of Canada,
-# Creston did not change its clocks.
-# note 2:
-# During WWII when the Federal Government legislated a mandatory clock change,
-# Creston did not oblige.
-# note 3:
-# There is no guarantee that Creston will remain on Mountain Standard Time
-# (UTC-7) forever.
-# The subject was debated at least once this year by the town Council.
-# http://www.bclocalnews.com/kootenay_rockies/crestonvalleyadvance/news/116760809.html
-
-# During a period WWII, summer time (Daylight saying) was mandatory in Canada.
-# In Creston, that was handled by shifting the area to PST (-8:00) then applying
-# summer time to cause the offset to be -7:00, the same as it had been before
-# the change.  It can be argued that the timezone abbreviation during this
-# period should be PDT rather than MST, but that doesn't seem important enough
-# (to anyone) to further complicate the rules.
-
-# The transition dates (and times) are guesses.
 
 # From Matt Johnson (2015-09-21):
 # Fort Nelson, BC, Canada will cancel DST this year.  So while previously they
@@ -2167,10 +2051,7 @@ Zone America/Fort_Nelson	-8:10:47 -	LMT	1884
 			-8:00	Vanc	P%sT	1987
 			-8:00	Canada	P%sT	2015 Mar  8  2:00
 			-7:00	-	MST
-Zone America/Creston	-7:46:04 -	LMT	1884
-			-7:00	-	MST	1916 Oct 1
-			-8:00	-	PST	1918 Jun 2
-			-7:00	-	MST
+# For Creston see America/Phoenix.
 
 # Northwest Territories, Nunavut, Yukon
 
@@ -2952,64 +2833,61 @@ Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  0:11:56
 
 # Anguilla
 # Antigua and Barbuda
-# See America/Port_of_Spain.
+# See America/Puerto_Rico.
 
-# Bahamas
-#
-# For 1899 Milne gives -5:09:29.5; round that.
-#
-# From P Chan (2020-11-27, corrected on 2020-12-02):
-# There were two periods of DST observed in 1942-1945: 1942-05-01
-# midnight to 1944-12-31 midnight and 1945-02-01 to 1945-10-17 midnight.
-# "midnight" should mean 24:00 from the context.
-#
-# War Time Order 1942 [1942-05-01] and War Time (No. 2) Order 1942  [1942-09-29]
-# Appendix to the Statutes of 7 George VI. and the Year 1942. p 34, 43
-# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA3-PA34
-# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA3-PA43
-#
-# War Time Order 1943 [1943-03-31] and War Time Order 1944 [1943-12-29]
-# Appendix to the Statutes of 8 George VI. and the Year 1943. p 9-10, 28-29
-# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA4-PA9
-# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA4-PA28
-#
-# War Time Order 1945 [1945-01-31] and the Order which revoke War Time Order
-# 1945 [1945-10-16] Appendix to the Statutes of 9 George VI. and the Year
-# 1945. p 160, 247-248
-# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA6-PA160
-# https://books.google.com/books?id=5rlNAQAAIAAJ&pg=RA6-PA247
-#
-# From Sue Williams (2006-12-07):
-# The Bahamas announced about a month ago that they plan to change their DST
-# rules to sync with the U.S. starting in 2007....
-# http://www.jonesbahamas.com/?c=45&a=10412
+# The Bahamas
+# See America/Toronto.
 
-# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Bahamas	1942	only	-	May	 1	24:00	1:00	W
-Rule	Bahamas	1944	only	-	Dec	31	24:00	0	S
-Rule	Bahamas	1945	only	-	Feb	 1	0:00	1:00	W
-Rule	Bahamas	1945	only	-	Aug	14	23:00u	1:00	P # Peace
-Rule	Bahamas	1945	only	-	Oct	17	24:00	0	S
-Rule	Bahamas	1964	1975	-	Oct	lastSun	2:00	0	S
-Rule	Bahamas	1964	1975	-	Apr	lastSun	2:00	1:00	D
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Nassau	-5:09:30 -	LMT	1912 Mar 2
-			-5:00	Bahamas	E%sT	1976
-			-5:00	US	E%sT
 
 # Barbados
 
 # For 1899 Milne gives -3:58:29.2; round that.
 
+# From P Chan (2020-12-09 and 2020-12-11):
+# Standard time of GMT-4 was adopted in 1911.
+# Definition of Time Act, 1911 (1911-7) [1911-08-28]
+# 1912, Laws of Barbados (5 v.), OCLC Number: 919801291, Vol. 4, Image No. 522
+# 1944, Laws of Barbados (5 v.), OCLC Number: 84548697, Vol. 4, Image No. 122
+# http://llmc.com/browse.aspx?type=2&coll=85&div=297
+#
+# DST was observed in 1942-44.
+# Defence (Daylight Saving) Regulations, 1942, 1942-04-13
+# Defence (Daylight Saving) (Repeal) Regulations, 1942, 1942-08-22
+# Defence (Daylight Saving) Regulations, 1943, 1943-04-16
+# Defence (Daylight Saving) (Repeal) Regulations, 1943, 1943-09-01
+# Defence (Daylight Saving) Regulations, 1944, 1944-03-21
+# [Defence (Daylight Saving) (Amendment) Regulations 1944, 1944-03-28]
+# Defence (Daylight Saving) (Repeal) Regulations, 1944, 1944-08-30
+#
+# 1914-, Subsidiary Legis., Annual Vols. OCLC Number: 226290591
+# 1942: Image Nos. 527-528, 555-556
+# 1943: Image Nos. 178-179, 198
+# 1944: Image Nos. 113-115, 129
+# http://llmc.com/titledescfull.aspx?type=2&coll=85&div=297&set=98437
+#
+# From Tim Parenti (2021-02-20):
+# The transitions below are derived from P Chan's sources, except that the 1977
+# through 1980 transitions are from Shanks & Pottenger since we have no better
+# data there.  Of particular note, the 1944 DST regulation only advanced the
+# time to "exactly three and a half hours later than Greenwich mean time", as
+# opposed to "three hours" in the 1942 and 1943 regulations.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
+Rule	Barb	1942	only	-	Apr	19	5:00u	1:00	D
+Rule	Barb	1942	only	-	Aug	31	6:00u	0	S
+Rule	Barb	1943	only	-	May	 2	5:00u	1:00	D
+Rule	Barb	1943	only	-	Sep	 5	6:00u	0	S
+Rule	Barb	1944	only	-	Apr	10	5:00u	0:30	-
+Rule	Barb	1944	only	-	Sep	10	6:00u	0	S
 Rule	Barb	1977	only	-	Jun	12	2:00	1:00	D
 Rule	Barb	1977	1978	-	Oct	Sun>=1	2:00	0	S
 Rule	Barb	1978	1980	-	Apr	Sun>=15	2:00	1:00	D
 Rule	Barb	1979	only	-	Sep	30	2:00	0	S
 Rule	Barb	1980	only	-	Sep	25	2:00	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Barbados	-3:58:29 -	LMT	1924 # Bridgetown
-			-3:58:29 -	BMT	1932 # Bridgetown Mean Time
+Zone America/Barbados	-3:58:29 -	LMT	1911 Aug 28 # Bridgetown
+			-4:00	Barb	A%sT	1944
+			-4:00	Barb	AST/-0330 1945
 			-4:00	Barb	A%sT
 
 # Belize
@@ -3170,6 +3048,9 @@ Zone Atlantic/Bermuda	-4:19:18 -	LMT	1890	# Hamilton
 			-4:00	Bermuda	A%sT	1974 Apr 28  2:00
 			-4:00	Canada	A%sT	1976
 			-4:00	US	A%sT
+
+# Caribbean Netherlands
+# See America/Puerto_Rico.
 
 # Cayman Is
 # See America/Panama.
@@ -3399,7 +3280,7 @@ Zone	America/Havana	-5:29:28 -	LMT	1890
 			-5:00	Cuba	C%sT
 
 # Dominica
-# See America/Port_of_Spain.
+# See America/Puerto_Rico.
 
 # Dominican Republic
 
@@ -3451,7 +3332,7 @@ Zone America/El_Salvador -5:56:48 -	LMT	1921 # San Salvador
 # Guadeloupe
 # St Barthélemy
 # St Martin (French part)
-# See America/Port_of_Spain.
+# See America/Puerto_Rico.
 
 # Guatemala
 #
@@ -3638,7 +3519,7 @@ Zone America/Martinique	-4:04:20 -      LMT	1890        # Fort-de-France
 			-4:00	-	AST
 
 # Montserrat
-# See America/Port_of_Spain.
+# See America/Puerto_Rico.
 
 # Nicaragua
 #
@@ -3710,6 +3591,7 @@ Zone	America/Managua	-5:45:08 -	LMT	1890
 Zone	America/Panama	-5:18:08 -	LMT	1890
 			-5:19:36 -	CMT	1908 Apr 22 # Colón Mean Time
 			-5:00	-	EST
+Link America/Panama America/Atikokan
 Link America/Panama America/Cayman
 
 # Puerto Rico
@@ -3719,10 +3601,29 @@ Zone America/Puerto_Rico -4:24:25 -	LMT	1899 Mar 28 12:00 # San Juan
 			-4:00	-	AST	1942 May  3
 			-4:00	US	A%sT	1946
 			-4:00	-	AST
+Link America/Puerto_Rico America/Anguilla
+Link America/Puerto_Rico America/Antigua
+Link America/Puerto_Rico America/Aruba
+Link America/Puerto_Rico America/Curacao
+Link America/Puerto_Rico America/Blanc-Sablon	# Quebec (Lower North Shore)
+Link America/Puerto_Rico America/Dominica
+Link America/Puerto_Rico America/Grenada
+Link America/Puerto_Rico America/Guadeloupe
+Link America/Puerto_Rico America/Kralendijk	# Caribbean Netherlands
+Link America/Puerto_Rico America/Lower_Princes	# Sint Maarten
+Link America/Puerto_Rico America/Marigot	# St Martin (French part)
+Link America/Puerto_Rico America/Montserrat
+Link America/Puerto_Rico America/Port_of_Spain	# Trinidad & Tobago
+Link America/Puerto_Rico America/St_Barthelemy	# St Barthélemy
+Link America/Puerto_Rico America/St_Kitts	# St Kitts & Nevis
+Link America/Puerto_Rico America/St_Lucia
+Link America/Puerto_Rico America/St_Thomas	# Virgin Islands (US)
+Link America/Puerto_Rico America/St_Vincent
+Link America/Puerto_Rico America/Tortola	# Virgin Islands (UK)
 
 # St Kitts-Nevis
 # St Lucia
-# See America/Port_of_Spain.
+# See America/Puerto_Rico.
 
 # St Pierre and Miquelon
 # There are too many St Pierres elsewhere, so we'll use 'Miquelon'.
@@ -3733,7 +3634,10 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 			-3:00	Canada	-03/-02
 
 # St Vincent and the Grenadines
-# See America/Port_of_Spain.
+# See America/Puerto_Rico.
+
+# Sint Maarten
+# See America/Puerto_Rico.
 
 # Turks and Caicos
 #
@@ -3804,8 +3708,8 @@ Zone America/Grand_Turk	-4:44:32 -	LMT	1890
 			-5:00	US	E%sT
 
 # British Virgin Is
-# Virgin Is
-# See America/Port_of_Spain.
+# US Virgin Is
+# See America/Puerto_Rico.
 
 
 # Local Variables:

--- a/make/data/tzdata/southamerica
+++ b/make/data/tzdata/southamerica
@@ -597,7 +597,7 @@ Zone America/Argentina/Ushuaia -4:33:12 - LMT	1894 Oct 31
 			-3:00	-	-03
 
 # Aruba
-Link America/Curacao America/Aruba
+# See America/Puerto_Rico.
 
 # Bolivia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
@@ -1392,35 +1392,14 @@ Zone	America/Bogota	-4:56:16 -	LMT	1884 Mar 13
 # no information; probably like America/Bogota
 
 # Curaçao
-
-# Milne gives 4:35:46.9 for Curaçao mean time; round to nearest.
+# See America/Puerto_Rico.
 #
-# From Paul Eggert (2006-03-22):
-# Shanks & Pottenger say that The Bottom and Philipsburg have been at
-# -4:00 since standard time was introduced on 1912-03-02; and that
-# Kralendijk and Rincon used Kralendijk Mean Time (-4:33:08) from
-# 1912-02-02 to 1965-01-01.  The former is dubious, since S&P also say
-# Saba Island has been like Curaçao.
-# This all predates our 1970 cutoff, though.
-#
-# By July 2007 Curaçao and St Maarten are planned to become
-# associated states within the Netherlands, much like Aruba;
-# Bonaire, Saba and St Eustatius would become directly part of the
-# Netherlands as Kingdom Islands.  This won't affect their time zones
-# though, as far as we know.
-#
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Curacao	-4:35:47 -	LMT	1912 Feb 12 # Willemstad
-			-4:30	-	-0430	1965
-			-4:00	-	AST
-
 # From Arthur David Olson (2011-06-15):
 # use links for places with new iso3166 codes.
 # The name "Lower Prince's Quarter" is both longer than fourteen characters
-# and contains an apostrophe; use "Lower_Princes" below.
-
-Link	America/Curacao	America/Lower_Princes	# Sint Maarten
-Link	America/Curacao	America/Kralendijk	# Caribbean Netherlands
+# and contains an apostrophe; use "Lower_Princes"....
+# From Paul Eggert (2021-09-29):
+# These backward-compatibility links now are in the 'northamerica' file.
 
 # Ecuador
 #
@@ -1563,11 +1542,40 @@ Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul
 			-3:00	-	-03
 
 # Guyana
+
+# From P Chan (2020-11-27):
+# https://books.google.com/books?id=5-5CAQAAMAAJ&pg=SA1-PA547
+# The Official Gazette of British Guiana. (New Series.) Vol. XL. July to
+# December, 1915, p 1547, lists as several notes:
+# "Local Mean Time 3 hours 52 mins. 39 secs. slow of Greenwich Mean Time
+# (Georgetown.) From 1st August, 1911, British Guiana Standard Mean Time 4
+# hours slow of Greenwich Mean Time, by notice in Official Gazette on 1st July,
+# 1911.  From 1st March, 1915, British Guiana Standard Mean Time 3 hours 45
+# mins. 0 secs. slow of Greenwich Mean Time, by notice in Official Gazette on
+# 23rd January, 1915."
+#
+# https://parliament.gov.gy/documents/acts/10923-act_no._27_of_1975_-_interpretation_and_general_clauses_(amendment)_act_1975.pdf
+# Interpretation and general clauses (Amendment) Act 1975 (Act No. 27 of 1975)
+# [dated 1975-07-31]
+# "This Act...shall come into operation on 1st August, 1975."
+# "...where any expression of time occurs...the time referred to shall signify
+# the standard time of Guyana which shall be three hours behind Greenwich Mean
+# Time."
+#
+# Circular No. 10/1992 dated 1992-03-20
+# https://dps.gov.gy/wp-content/uploads/2018/12/1992-03-20-Circular-010.pdf
+# "...cabinet has decided that with effect from Sunday 29th March, 1992, Guyana
+# Standard Time would be re-established at 01:00 hours by adjusting the hands
+# of the clock back to 24:00 hours."
+# Legislated in the Interpretation and general clauses (Amendment) Act 1992
+# (Act No. 6 of 1992) [passed 1992-03-27, published 1992-04-18]
+# https://parliament.gov.gy/documents/acts/5885-6_of_1992_interpretation_and_general_clauses_(amendment)_act_1992.pdf
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	America/Guyana	-3:52:40 -	LMT	1915 Mar    # Georgetown
-			-3:45	-	-0345	1975 Jul 31
-			-3:00	-	-03	1991
-# IATA SSIM (1996-06) says -4:00.  Assume a 1991 switch.
+Zone	America/Guyana	-3:52:39 -	LMT	1911 Aug  1 # Georgetown
+			-4:00	-	-04	1915 Mar  1
+			-3:45	-	-0345	1975 Aug  1
+			-3:00	-	-03	1992 Mar 29  1:00
 			-4:00	-	-04
 
 # Paraguay
@@ -1708,24 +1716,7 @@ Zone America/Paramaribo	-3:40:40 -	LMT	1911
 			-3:00	-	-03
 
 # Trinidad and Tobago
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Port_of_Spain -4:06:04 -	LMT	1912 Mar 2
-			-4:00	-	AST
-
-# These all agree with Trinidad and Tobago since 1970.
-Link America/Port_of_Spain America/Anguilla
-Link America/Port_of_Spain America/Antigua
-Link America/Port_of_Spain America/Dominica
-Link America/Port_of_Spain America/Grenada
-Link America/Port_of_Spain America/Guadeloupe
-Link America/Port_of_Spain America/Marigot	# St Martin (French part)
-Link America/Port_of_Spain America/Montserrat
-Link America/Port_of_Spain America/St_Barthelemy # St Barthélemy
-Link America/Port_of_Spain America/St_Kitts	# St Kitts & Nevis
-Link America/Port_of_Spain America/St_Lucia
-Link America/Port_of_Spain America/St_Thomas	# Virgin Islands (US)
-Link America/Port_of_Spain America/St_Vincent
-Link America/Port_of_Spain America/Tortola	# Virgin Islands (UK)
+# See America/Puerto_Rico.
 
 # Uruguay
 # From Paul Eggert (1993-11-18):

--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -26,7 +26,7 @@
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 #
-# From Paul Eggert (2018-06-27):
+# From Paul Eggert (2021-09-20):
 # This file is intended as a backward-compatibility aid for older programs.
 # New programs should use zone1970.tab.  This file is like zone1970.tab (see
 # zone1970.tab's comments), but with the following additional restrictions:
@@ -38,6 +38,9 @@
 # of a region identified by a country code and of a timezone where civil
 # clocks have agreed since 1970; this is a narrower definition than
 # that of zone1970.tab.
+#
+# Unlike zone1970.tab, a row's third column can be a Link from
+# 'backward' instead of a Zone.
 #
 # This table is intended as an aid for users, to help them select timezones
 # appropriate for their practical needs.  It is not intended to take or
@@ -251,7 +254,7 @@ KE	-0117+03649	Africa/Nairobi
 KG	+4254+07436	Asia/Bishkek
 KH	+1133+10455	Asia/Phnom_Penh
 KI	+0125+17300	Pacific/Tarawa	Gilbert Islands
-KI	-0308-17105	Pacific/Enderbury	Phoenix Islands
+KI	-0247-17143	Pacific/Kanton	Phoenix Islands
 KI	+0152-15720	Pacific/Kiritimati	Line Islands
 KM	-1141+04316	Indian/Comoro
 KN	+1718-06243	America/St_Kitts
@@ -414,7 +417,7 @@ TK	-0922-17114	Pacific/Fakaofo
 TL	-0833+12535	Asia/Dili
 TM	+3757+05823	Asia/Ashgabat
 TN	+3648+01011	Africa/Tunis
-TO	-2110-17510	Pacific/Tongatapu
+TO	-210800-1751200	Pacific/Tongatapu
 TR	+4101+02858	Europe/Istanbul
 TT	+1039-06131	America/Port_of_Spain
 TV	-0831+17913	Pacific/Funafuti

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2333,6 +2333,13 @@ const RegMask Matcher::method_handle_invoke_SP_save_mask() {
 bool size_fits_all_mem_uses(AddPNode* addp, int shift) {
   for (DUIterator_Fast imax, i = addp->fast_outs(imax); i < imax; i++) {
     Node* u = addp->fast_out(i);
+    if (u->is_LoadStore()) {
+      // On AArch64, LoadStoreNodes (i.e. compare and swap
+      // instructions) only take register indirect as an operand, so
+      // any attempt to use an AddPNode as an input to a LoadStoreNode
+      // must fail.
+      return false;
+    }
     if (u->is_Mem()) {
       int opsize = u->as_Mem()->memory_size();
       assert(opsize > 0, "unexpected memory operand size");

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5250,7 +5250,7 @@ void MacroAssembler::cache_wb(Address line) {
   assert(line.offset() == 0, "offset should be 0");
   // would like to assert this
   // assert(line._ext.shift == 0, "shift should be zero");
-  if (VM_Version::supports_dcpop()) {
+  if (VM_Version::features() & VM_Version::CPU_DCPOP) {
     // writeback using clear virtual address to point of persistence
     dc(Assembler::CVAP, line.base());
   } else {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -174,10 +174,6 @@ void VM_Version::initialize() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
-  // we assume the worst and assume we could be on a big little system and have
-  // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
   char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -24,43 +24,14 @@
  */
 
 #include "precompiled.hpp"
-#include "asm/macroAssembler.hpp"
-#include "asm/macroAssembler.inline.hpp"
-#include "memory/resourceArea.hpp"
+#include "runtime/arguments.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
-#include "runtime/stubCodeGenerator.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/macros.hpp"
 
 #include OS_HEADER_INLINE(os)
-
-#include <sys/auxv.h>
-#include <asm/hwcap.h>
-
-#ifndef HWCAP_AES
-#define HWCAP_AES   (1<<3)
-#endif
-
-#ifndef HWCAP_PMULL
-#define HWCAP_PMULL (1<<4)
-#endif
-
-#ifndef HWCAP_SHA1
-#define HWCAP_SHA1  (1<<5)
-#endif
-
-#ifndef HWCAP_SHA2
-#define HWCAP_SHA2  (1<<6)
-#endif
-
-#ifndef HWCAP_CRC32
-#define HWCAP_CRC32 (1<<7)
-#endif
-
-#ifndef HWCAP_ATOMICS
-#define HWCAP_ATOMICS (1<<8)
-#endif
 
 int VM_Version::_cpu;
 int VM_Version::_model;
@@ -68,58 +39,20 @@ int VM_Version::_model2;
 int VM_Version::_variant;
 int VM_Version::_revision;
 int VM_Version::_stepping;
-bool VM_Version::_dcpop;
-VM_Version::PsrInfo VM_Version::_psr_info   = { 0, };
 
-static BufferBlob* stub_blob;
-static const int stub_size = 550;
+int VM_Version::_zva_length;
+int VM_Version::_dcache_line_size;
+int VM_Version::_icache_line_size;
+int VM_Version::_initial_sve_vector_length;
 
-extern "C" {
-  typedef void (*getPsrInfo_stub_t)(void*);
-}
-static getPsrInfo_stub_t getPsrInfo_stub = NULL;
-
-
-class VM_Version_StubGenerator: public StubCodeGenerator {
- public:
-
-  VM_Version_StubGenerator(CodeBuffer *c) : StubCodeGenerator(c) {}
-
-  address generate_getPsrInfo() {
-    StubCodeMark mark(this, "VM_Version", "getPsrInfo_stub");
-#   define __ _masm->
-    address start = __ pc();
-
-    // void getPsrInfo(VM_Version::PsrInfo* psr_info);
-
-    address entry = __ pc();
-
-    __ enter();
-
-    __ get_dczid_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::dczid_el0_offset())));
-
-    __ get_ctr_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::ctr_el0_offset())));
-
-    __ leave();
-    __ ret(lr);
-
-#   undef __
-
-    return start;
-  }
-};
-
-
-void VM_Version::get_processor_features() {
+void VM_Version::initialize() {
   _supports_cx8 = true;
   _supports_atomic_getset4 = true;
   _supports_atomic_getadd4 = true;
   _supports_atomic_getset8 = true;
   _supports_atomic_getadd8 = true;
 
-  getPsrInfo_stub(&_psr_info);
+  get_os_cpu_info();
 
   int dcache_line = VM_Version::dcache_line_size();
 
@@ -161,44 +94,12 @@ void VM_Version::get_processor_features() {
     SoftwarePrefetchHintDistance &= ~7;
   }
 
-  unsigned long auxv = getauxval(AT_HWCAP);
-
-  char buf[512];
-
-  _features = auxv;
-
-  int cpu_lines = 0;
-  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
-    // need a large buffer as the flags line may include lots of text
-    char buf[1024], *p;
-    while (fgets(buf, sizeof (buf), f) != NULL) {
-      if ((p = strchr(buf, ':')) != NULL) {
-        long v = strtol(p+1, NULL, 0);
-        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
-          _cpu = v;
-          cpu_lines++;
-        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
-          _variant = v;
-        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
-          if (_model != v)  _model2 = _model;
-          _model = v;
-        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
-          _revision = v;
-        } else if (strncmp(buf, "flags", sizeof("flags") - 1) == 0) {
-          if (strstr(p+1, "dcpop")) {
-            _dcpop = true;
-          }
-        }
-      }
-    }
-    fclose(f);
-  }
 
   if (os::supports_map_sync()) {
     // if dcpop is available publish data cache line flush size via
     // generic field, otherwise let if default to zero thereby
     // disabling writeback
-    if (_dcpop) {
+    if (_features & CPU_DCPOP) {
       _data_cache_line_flush_size = dcache_line;
     }
   }
@@ -273,27 +174,31 @@ void VM_Version::get_processor_features() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cpu_lines == 1) then if _model is an A57 (0xd07)
+  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
   // we assume the worst and assume we could be on a big little system and have
   // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && cpu_lines == 1 && _model == 0xd07) _features |= CPU_A53MAC;
+  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
+  char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
   if (_model2) sprintf(buf+strlen(buf), "(0x%03x)", _model2);
-  if (auxv & HWCAP_ASIMD) strcat(buf, ", simd");
-  if (auxv & HWCAP_CRC32) strcat(buf, ", crc");
-  if (auxv & HWCAP_AES)   strcat(buf, ", aes");
-  if (auxv & HWCAP_SHA1)  strcat(buf, ", sha1");
-  if (auxv & HWCAP_SHA2)  strcat(buf, ", sha256");
-  if (auxv & HWCAP_ATOMICS) strcat(buf, ", lse");
+  if (_features & CPU_ASIMD) strcat(buf, ", simd");
+  if (_features & CPU_CRC32) strcat(buf, ", crc");
+  if (_features & CPU_AES)   strcat(buf, ", aes");
+  if (_features & CPU_SHA1)  strcat(buf, ", sha1");
+  if (_features & CPU_SHA2)  strcat(buf, ", sha256");
+  if (_features & CPU_SHA512) strcat(buf, ", sha512");
+  if (_features & CPU_LSE) strcat(buf, ", lse");
+  if (_features & CPU_SVE) strcat(buf, ", sve");
+  if (_features & CPU_SVE2) strcat(buf, ", sve2");
 
   _features_string = os::strdup(buf);
 
   if (FLAG_IS_DEFAULT(UseCRC32)) {
-    UseCRC32 = (auxv & HWCAP_CRC32) != 0;
+    UseCRC32 = (_features & CPU_CRC32) != 0;
   }
 
-  if (UseCRC32 && (auxv & HWCAP_CRC32) == 0) {
+  if (UseCRC32 && (_features & CPU_CRC32) == 0) {
     warning("UseCRC32 specified, but not supported on this CPU");
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
@@ -307,7 +212,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }
 
-  if (auxv & HWCAP_ATOMICS) {
+  if (_features & CPU_LSE) {
     if (FLAG_IS_DEFAULT(UseLSE))
       FLAG_SET_DEFAULT(UseLSE, true);
   } else {
@@ -317,7 +222,7 @@ void VM_Version::get_processor_features() {
     }
   }
 
-  if (auxv & HWCAP_AES) {
+  if (_features & CPU_AES) {
     UseAES = UseAES || FLAG_IS_DEFAULT(UseAES);
     UseAESIntrinsics =
         UseAESIntrinsics || (UseAES && FLAG_IS_DEFAULT(UseAESIntrinsics));
@@ -345,7 +250,7 @@ void VM_Version::get_processor_features() {
     UseCRC32Intrinsics = true;
   }
 
-  if (auxv & HWCAP_CRC32) {
+  if (_features & CPU_CRC32) {
     if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
       FLAG_SET_DEFAULT(UseCRC32CIntrinsics, true);
     }
@@ -358,7 +263,12 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
-  if (auxv & (HWCAP_SHA1 | HWCAP_SHA2)) {
+  if (UseMD5Intrinsics) {
+    warning("MD5 intrinsics are not available on this CPU");
+    FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
+  }
+
+  if (_features & (CPU_SHA1 | CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       FLAG_SET_DEFAULT(UseSHA, true);
     }
@@ -367,7 +277,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA1)) {
+  if (UseSHA && (_features & CPU_SHA1)) {
     if (FLAG_IS_DEFAULT(UseSHA1Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA1Intrinsics, true);
     }
@@ -376,7 +286,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA1Intrinsics, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA2)) {
+  if (UseSHA && (_features & CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA256Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA256Intrinsics, true);
     }
@@ -385,7 +295,12 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA256Intrinsics, false);
   }
 
-  if (UseSHA512Intrinsics) {
+  if (UseSHA && (_features & CPU_SHA512)) {
+    // Do not auto-enable UseSHA512Intrinsics until it has been fully tested on hardware
+    // if (FLAG_IS_DEFAULT(UseSHA512Intrinsics)) {
+      // FLAG_SET_DEFAULT(UseSHA512Intrinsics, true);
+    // }
+  } else if (UseSHA512Intrinsics) {
     warning("Intrinsics for SHA-384 and SHA-512 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseSHA512Intrinsics, false);
   }
@@ -394,7 +309,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (auxv & HWCAP_PMULL) {
+  if (_features & CPU_PMULL) {
     if (FLAG_IS_DEFAULT(UseGHASHIntrinsics)) {
       FLAG_SET_DEFAULT(UseGHASHIntrinsics, true);
     }
@@ -413,6 +328,18 @@ void VM_Version::get_processor_features() {
   } else if (UseBlockZeroing) {
     warning("DC ZVA is not available on this CPU");
     FLAG_SET_DEFAULT(UseBlockZeroing, false);
+  }
+
+  if (_features & CPU_SVE) {
+    if (FLAG_IS_DEFAULT(UseSVE)) {
+      FLAG_SET_DEFAULT(UseSVE, (_features & CPU_SVE2) ? 2 : 1);
+    }
+    if (UseSVE > 0) {
+      _initial_sve_vector_length = get_current_sve_vector_length();
+    }
+  } else if (UseSVE > 0) {
+    warning("UseSVE specified, but not supported on current CPU. Disabling SVE.");
+    FLAG_SET_DEFAULT(UseSVE, 0);
   }
 
   // This machine allows unaligned memory accesses
@@ -449,6 +376,48 @@ void VM_Version::get_processor_features() {
     UseMontgomerySquareIntrinsic = true;
   }
 
+  if (UseSVE > 0) {
+    if (FLAG_IS_DEFAULT(MaxVectorSize)) {
+      MaxVectorSize = _initial_sve_vector_length;
+    } else if (MaxVectorSize < 16) {
+      warning("SVE does not support vector length less than 16 bytes. Disabling SVE.");
+      UseSVE = 0;
+    } else if ((MaxVectorSize % 16) == 0 && is_power_of_2(MaxVectorSize)) {
+      int new_vl = set_and_get_current_sve_vector_lenght(MaxVectorSize);
+      _initial_sve_vector_length = new_vl;
+      // Update MaxVectorSize to the largest supported value.
+      if (new_vl < 0) {
+        vm_exit_during_initialization(
+          err_msg("Current system does not support SVE vector length for MaxVectorSize: %d",
+                  (int)MaxVectorSize));
+      } else if (new_vl != MaxVectorSize) {
+        warning("Current system only supports max SVE vector length %d. Set MaxVectorSize to %d",
+                new_vl, new_vl);
+      }
+      MaxVectorSize = new_vl;
+    } else {
+      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
+    }
+  }
+
+  if (UseSVE == 0) {  // NEON
+    int min_vector_size = 8;
+    int max_vector_size = 16;
+    if (!FLAG_IS_DEFAULT(MaxVectorSize)) {
+      if (!is_power_of_2(MaxVectorSize)) {
+        vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
+      } else if (MaxVectorSize < min_vector_size) {
+        warning("MaxVectorSize must be at least %i on this platform", min_vector_size);
+        FLAG_SET_DEFAULT(MaxVectorSize, min_vector_size);
+      } else if (MaxVectorSize > max_vector_size) {
+        warning("MaxVectorSize must be at most %i on this platform", max_vector_size);
+        FLAG_SET_DEFAULT(MaxVectorSize, max_vector_size);
+      }
+    } else {
+      FLAG_SET_DEFAULT(MaxVectorSize, 16);
+    }
+  }
+
   if (FLAG_IS_DEFAULT(OptoScheduling)) {
     OptoScheduling = true;
   }
@@ -457,22 +426,6 @@ void VM_Version::get_processor_features() {
     AlignVector = AvoidUnalignedAccesses;
   }
 #endif
-}
-
-void VM_Version::initialize() {
-  ResourceMark rm;
-
-  stub_blob = BufferBlob::create("getPsrInfo_stub", stub_size);
-  if (stub_blob == NULL) {
-    vm_exit_during_initialization("Unable to allocate getPsrInfo_stub");
-  }
-
-  CodeBuffer c(stub_blob);
-  VM_Version_StubGenerator g(&c);
-  getPsrInfo_stub = CAST_TO_FN_PTR(getPsrInfo_stub_t,
-                                   g.generate_getPsrInfo());
-
-  get_processor_features();
 
   UNSUPPORTED_OPTION(CriticalJNINatives);
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -40,13 +40,20 @@ protected:
   static int _variant;
   static int _revision;
   static int _stepping;
-  static bool _dcpop;
-  struct PsrInfo {
-    uint32_t dczid_el0;
-    uint32_t ctr_el0;
-  };
-  static PsrInfo _psr_info;
-  static void get_processor_features();
+
+  static int _zva_length;
+  static int _dcache_line_size;
+  static int _icache_line_size;
+  static int _initial_sve_vector_length;
+
+  // Read additional info using OS-specific interfaces
+  static void get_os_cpu_info();
+
+  // Sets the SVE length and returns a new actual value or negative on error.
+  // If the len is larger than the system largest supported SVE vector length,
+  // the function sets the largest supported value.
+  static int set_and_get_current_sve_vector_lenght(int len);
+  static int get_current_sve_vector_length();
 
 public:
   // Initialization
@@ -96,8 +103,13 @@ public:
     CPU_SHA2         = (1<<6),
     CPU_CRC32        = (1<<7),
     CPU_LSE          = (1<<8),
-    CPU_STXR_PREFETCH= (1 << 29),
-    CPU_A53MAC       = (1 << 30),
+    CPU_DCPOP        = (1<<16),
+    CPU_SHA512       = (1<<21),
+    CPU_SVE          = (1<<22),
+    // flags above must follow Linux HWCAP
+    CPU_SVE2         = (1<<28),
+    CPU_STXR_PREFETCH= (1<<29),
+    CPU_A53MAC       = (1<<30),
   };
 
   static int cpu_family()                     { return _cpu; }
@@ -105,25 +117,17 @@ public:
   static int cpu_model2()                     { return _model2; }
   static int cpu_variant()                    { return _variant; }
   static int cpu_revision()                   { return _revision; }
-  static bool supports_dcpop()                { return _dcpop; }
-  static ByteSize dczid_el0_offset() { return byte_offset_of(PsrInfo, dczid_el0); }
-  static ByteSize ctr_el0_offset()   { return byte_offset_of(PsrInfo, ctr_el0); }
-  static bool is_zva_enabled() {
-    // Check the DZP bit (bit 4) of dczid_el0 is zero
-    // and block size (bit 0~3) is not zero.
-    return ((_psr_info.dczid_el0 & 0x10) == 0 &&
-            (_psr_info.dczid_el0 & 0xf) != 0);
-  }
+
+  static bool is_zva_enabled() { return 0 <= _zva_length; }
   static int zva_length() {
     assert(is_zva_enabled(), "ZVA not available");
-    return 4 << (_psr_info.dczid_el0 & 0xf);
+    return _zva_length;
   }
-  static int icache_line_size() {
-    return (1 << (_psr_info.ctr_el0 & 0x0f)) * 4;
-  }
-  static int dcache_line_size() {
-    return (1 << ((_psr_info.ctr_el0 >> 16) & 0x0f)) * 4;
-  }
+
+  static int icache_line_size() { return _icache_line_size; }
+  static int dcache_line_size() { return _dcache_line_size; }
+  static int get_initial_sve_vector_length()  { return _initial_sve_vector_length; };
+
   static bool supports_fast_class_init_checks() { return true; }
 };
 

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -27,3 +27,140 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+
+#ifndef HWCAP_AES
+#define HWCAP_AES   (1<<3)
+#endif
+
+#ifndef HWCAP_PMULL
+#define HWCAP_PMULL (1<<4)
+#endif
+
+#ifndef HWCAP_SHA1
+#define HWCAP_SHA1  (1<<5)
+#endif
+
+#ifndef HWCAP_SHA2
+#define HWCAP_SHA2  (1<<6)
+#endif
+
+#ifndef HWCAP_CRC32
+#define HWCAP_CRC32 (1<<7)
+#endif
+
+#ifndef HWCAP_ATOMICS
+#define HWCAP_ATOMICS (1<<8)
+#endif
+
+#ifndef HWCAP_DCPOP
+#define HWCAP_DCPOP (1<<16)
+#endif
+
+#ifndef HWCAP_SHA512
+#define HWCAP_SHA512 (1 << 21)
+#endif
+
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1 << 22)
+#endif
+
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1 << 1)
+#endif
+
+#ifndef PR_SVE_GET_VL
+// For old toolchains which do not have SVE related macros defined.
+#define PR_SVE_SET_VL   50
+#define PR_SVE_GET_VL   51
+#endif
+
+int VM_Version::get_current_sve_vector_length() {
+  assert(_features & CPU_SVE, "should not call this");
+  return prctl(PR_SVE_GET_VL);
+}
+
+int VM_Version::set_and_get_current_sve_vector_lenght(int length) {
+  assert(_features & CPU_SVE, "should not call this");
+  int new_length = prctl(PR_SVE_SET_VL, length);
+  return new_length;
+}
+
+void VM_Version::get_os_cpu_info() {
+
+  uint64_t auxv = getauxval(AT_HWCAP);
+  uint64_t auxv2 = getauxval(AT_HWCAP2);
+
+  static_assert(CPU_FP      == HWCAP_FP);
+  static_assert(CPU_ASIMD   == HWCAP_ASIMD);
+  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM);
+  static_assert(CPU_AES     == HWCAP_AES);
+  static_assert(CPU_PMULL   == HWCAP_PMULL);
+  static_assert(CPU_SHA1    == HWCAP_SHA1);
+  static_assert(CPU_SHA2    == HWCAP_SHA2);
+  static_assert(CPU_CRC32   == HWCAP_CRC32);
+  static_assert(CPU_LSE     == HWCAP_ATOMICS);
+  static_assert(CPU_DCPOP   == HWCAP_DCPOP);
+  static_assert(CPU_SHA512  == HWCAP_SHA512);
+  static_assert(CPU_SVE     == HWCAP_SVE);
+  _features = auxv & (
+      HWCAP_FP      |
+      HWCAP_ASIMD   |
+      HWCAP_EVTSTRM |
+      HWCAP_AES     |
+      HWCAP_PMULL   |
+      HWCAP_SHA1    |
+      HWCAP_SHA2    |
+      HWCAP_CRC32   |
+      HWCAP_ATOMICS |
+      HWCAP_DCPOP   |
+      HWCAP_SHA512  |
+      HWCAP_SVE);
+
+  if (auxv2 & HWCAP2_SVE2) _features |= CPU_SVE2;
+
+  uint64_t ctr_el0;
+  uint64_t dczid_el0;
+  __asm__ (
+    "mrs %0, CTR_EL0\n"
+    "mrs %1, DCZID_EL0\n"
+    : "=r"(ctr_el0), "=r"(dczid_el0)
+  );
+
+  _icache_line_size = (1 << (ctr_el0 & 0x0f)) * 4;
+  _dcache_line_size = (1 << ((ctr_el0 >> 16) & 0x0f)) * 4;
+
+  if (!(dczid_el0 & 0x10)) {
+    _zva_length = 4 << (dczid_el0 & 0xf);
+  }
+
+  int cpu_lines = 0;
+  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
+    // need a large buffer as the flags line may include lots of text
+    char buf[1024], *p;
+    while (fgets(buf, sizeof (buf), f) != NULL) {
+      if ((p = strchr(buf, ':')) != NULL) {
+        long v = strtol(p+1, NULL, 0);
+        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
+          _cpu = v;
+          cpu_lines++;
+        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
+          _variant = v;
+        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
+          if (_model != v)  _model2 = _model;
+          _model = v;
+        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
+          _revision = v;
+        } else if (strncmp(buf, "flags", sizeof("flags") - 1) == 0) {
+          if (strstr(p+1, "dcpop")) {
+            guarantee(_features & CPU_DCPOP, "dcpop availability should be consistent");
+          }
+        }
+      }
+    }
+    fclose(f);
+  }
+  guarantee(cpu_lines == os::processor_count(), "core count should be consistent");
+}

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -137,7 +137,6 @@ void VM_Version::get_os_cpu_info() {
     _zva_length = 4 << (dczid_el0 & 0xf);
   }
 
-  int cpu_lines = 0;
   if (FILE *f = fopen("/proc/cpuinfo", "r")) {
     // need a large buffer as the flags line may include lots of text
     char buf[1024], *p;
@@ -146,7 +145,6 @@ void VM_Version::get_os_cpu_info() {
         long v = strtol(p+1, NULL, 0);
         if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
           _cpu = v;
-          cpu_lines++;
         } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
           _variant = v;
         } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
@@ -163,5 +161,4 @@ void VM_Version::get_os_cpu_info() {
     }
     fclose(f);
   }
-  guarantee(cpu_lines == os::processor_count(), "core count should be consistent");
 }

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2019, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,18 +93,19 @@ void VM_Version::get_os_cpu_info() {
   uint64_t auxv = getauxval(AT_HWCAP);
   uint64_t auxv2 = getauxval(AT_HWCAP2);
 
-  static_assert(CPU_FP      == HWCAP_FP);
-  static_assert(CPU_ASIMD   == HWCAP_ASIMD);
-  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM);
-  static_assert(CPU_AES     == HWCAP_AES);
-  static_assert(CPU_PMULL   == HWCAP_PMULL);
-  static_assert(CPU_SHA1    == HWCAP_SHA1);
-  static_assert(CPU_SHA2    == HWCAP_SHA2);
-  static_assert(CPU_CRC32   == HWCAP_CRC32);
-  static_assert(CPU_LSE     == HWCAP_ATOMICS);
-  static_assert(CPU_DCPOP   == HWCAP_DCPOP);
-  static_assert(CPU_SHA512  == HWCAP_SHA512);
-  static_assert(CPU_SVE     == HWCAP_SVE);
+  static_assert(CPU_FP      == HWCAP_FP,      "Flag CPU_FP must follow Linux HWCAP");
+  static_assert(CPU_ASIMD   == HWCAP_ASIMD,   "Flag CPU_ASIMD must follow Linux HWCAP");
+  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM, "Flag CPU_EVTSTRM must follow Linux HWCAP");
+  static_assert(CPU_AES     == HWCAP_AES,     "Flag CPU_AES must follow Linux HWCAP");
+  static_assert(CPU_PMULL   == HWCAP_PMULL,   "Flag CPU_PMULL must follow Linux HWCAP");
+  static_assert(CPU_SHA1    == HWCAP_SHA1,    "Flag CPU_SHA1 must follow Linux HWCAP");
+  static_assert(CPU_SHA2    == HWCAP_SHA2,    "Flag CPU_SHA2 must follow Linux HWCAP");
+  static_assert(CPU_CRC32   == HWCAP_CRC32,   "Flag CPU_CRC32 must follow Linux HWCAP");
+  static_assert(CPU_LSE     == HWCAP_ATOMICS, "Flag CPU_LSE must follow Linux HWCAP");
+  static_assert(CPU_DCPOP   == HWCAP_DCPOP,   "Flag CPU_DCPOP must follow Linux HWCAP");
+  static_assert(CPU_SHA3    == HWCAP_SHA3,    "Flag CPU_SHA3 must follow Linux HWCAP");
+  static_assert(CPU_SHA512  == HWCAP_SHA512,  "Flag CPU_SHA512 must follow Linux HWCAP");
+  static_assert(CPU_SVE     == HWCAP_SVE,     "Flag CPU_SVE must follow Linux HWCAP");
   _features = auxv & (
       HWCAP_FP      |
       HWCAP_ASIMD   |

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -40,6 +40,7 @@
 #include "jfr/writers/jfrTypeWriterHost.hpp"
 #include "memory/iterator.hpp"
 #include "memory/resourceArea.hpp"
+#include "memory/universe.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
@@ -62,6 +63,7 @@ static JfrArtifactSet* _artifacts = NULL;
 static JfrArtifactClosure* _subsystem_callback = NULL;
 static bool _class_unload = false;
 static bool _flushpoint = false;
+static bool _clear_artifacts = false;
 
 // incremented on each rotation
 static u8 checkpoint_id = 1;
@@ -82,6 +84,10 @@ static bool previous_epoch() {
   return !current_epoch();
 }
 
+static bool is_initial_typeset_for_chunk() {
+  return _clear_artifacts && !_class_unload;
+}
+
 static bool is_complete() {
   return !_artifacts->has_klass_entries() && current_epoch();
 }
@@ -96,6 +102,35 @@ static traceid mark_symbol(Symbol* symbol, bool leakp) {
 
 static traceid get_bootstrap_name(bool leakp) {
   return create_symbol_id(_artifacts->bootstrap_name(leakp));
+}
+
+static const char* primitive_name(KlassPtr type_array_klass) {
+  switch (type_array_klass->name()->base()[1]) {
+    case JVM_SIGNATURE_BOOLEAN: return "boolean";
+    case JVM_SIGNATURE_BYTE: return "byte";
+    case JVM_SIGNATURE_CHAR: return "char";
+    case JVM_SIGNATURE_SHORT: return "short";
+    case JVM_SIGNATURE_INT: return "int";
+    case JVM_SIGNATURE_LONG: return "long";
+    case JVM_SIGNATURE_FLOAT: return "float";
+    case JVM_SIGNATURE_DOUBLE: return "double";
+  }
+  assert(false, "invalid type array klass");
+  return NULL;
+}
+
+static Symbol* primitive_symbol(KlassPtr type_array_klass) {
+  if (type_array_klass == NULL) {
+    // void.class
+    static Symbol* const void_class_name = SymbolTable::probe("void", 4);
+    assert(void_class_name != NULL, "invariant");
+    return void_class_name;
+  }
+  const char* const primitive_type_str = primitive_name(type_array_klass);
+  assert(primitive_type_str != NULL, "invariant");
+  Symbol* const primitive_type_sym = SymbolTable::probe(primitive_type_str, (int)strlen(primitive_type_str));
+  assert(primitive_type_sym != NULL, "invariant");
+  return primitive_type_sym;
 }
 
 template <typename T>
@@ -151,6 +186,11 @@ template <typename T>
 static s4 get_flags(const T* ptr) {
   assert(ptr != NULL, "invariant");
   return ptr->access_flags().get_flags();
+}
+
+// Same as JVM_GetClassModifiers
+static u4 get_primitive_flags() {
+  return JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
 }
 
 static bool is_unsafe_anonymous(const Klass* klass) {
@@ -224,6 +264,27 @@ static void do_klass(Klass* klass) {
   _subsystem_callback->do_artifact(klass);
 }
 
+
+static traceid primitive_id(KlassPtr array_klass) {
+  if (array_klass == NULL) {
+    // The first klass id is reserved for the void.class.
+    return LAST_TYPE_ID + 1;
+  }
+  // Derive the traceid for a primitive mirror from its associated array klass (+1).
+  return JfrTraceId::load_raw(array_klass) + 1;
+}
+
+static void write_primitive(JfrCheckpointWriter* writer, KlassPtr type_array_klass) {
+  assert(writer != NULL, "invariant");
+  assert(_artifacts != NULL, "invariant");
+  writer->write(primitive_id(type_array_klass));
+  writer->write(cld_id(get_cld(Universe::boolArrayKlassObj()), false));
+  writer->write(mark_symbol(primitive_symbol(type_array_klass), false));
+  writer->write(package_id(Universe::boolArrayKlassObj(), false));
+  writer->write(get_primitive_flags());
+  writer->write<bool>(false);
+}
+
 static void do_loader_klass(const Klass* klass) {
   if (klass != NULL && _artifacts->should_do_loader_klass(klass)) {
     if (_leakp_writer != NULL) {
@@ -294,6 +355,28 @@ static void do_classloaders() {
   assert(mark_stack.is_empty(), "invariant");
 }
 
+static int primitives_count = 9;
+
+// A mirror representing a primitive class (e.g. int.class) has no reified Klass*,
+// instead it has an associated TypeArrayKlass* (e.g. int[].class).
+// We can use the TypeArrayKlass* as a proxy for deriving the id of the primitive class.
+// The exception is the void.class, which has neither a Klass* nor a TypeArrayKlass*.
+// It will use a reserved constant.
+static void do_primitives() {
+  // Only write the primitive classes once per chunk.
+  if (is_initial_typeset_for_chunk()) {
+    write_primitive(_writer, Universe::boolArrayKlassObj());
+    write_primitive(_writer, Universe::byteArrayKlassObj());
+    write_primitive(_writer, Universe::charArrayKlassObj());
+    write_primitive(_writer, Universe::shortArrayKlassObj());
+    write_primitive(_writer, Universe::intArrayKlassObj());
+    write_primitive(_writer, Universe::longArrayKlassObj());
+    write_primitive(_writer, Universe::floatArrayKlassObj());
+    write_primitive(_writer, Universe::doubleArrayKlassObj());
+    write_primitive(_writer, NULL); // void.class
+  }
+}
+
 static void do_object() {
   SET_TRANSIENT(SystemDictionary::Object_klass());
   do_klass(SystemDictionary::Object_klass());
@@ -306,6 +389,7 @@ static void do_klasses() {
   }
   JfrTraceIdLoadBarrier::do_klasses(&do_klass, previous_epoch());
   do_classloaders();
+  do_primitives();
   do_object();
 }
 
@@ -350,6 +434,11 @@ static bool write_klasses() {
     CompositeKlassCallback callback(&ckwr);
     _subsystem_callback = &callback;
     do_klasses();
+  }
+  if (is_initial_typeset_for_chunk()) {
+    // Because the set of primitives is written outside the callback,
+    // their count is not automatically incremented.
+    kw.add(primitives_count);
   }
   if (is_complete()) {
     return false;
@@ -978,8 +1067,6 @@ typedef Wrapper<KlassPtr, ClearArtifact> ClearKlassBits;
 typedef Wrapper<MethodPtr, ClearArtifact> ClearMethodFlag;
 typedef MethodIteratorHost<ClearMethodFlag, ClearKlassBits, AlwaysTrue, false> ClearKlassAndMethods;
 
-static bool clear_artifacts = false;
-
 static void clear_klasses_and_methods() {
   ClearKlassAndMethods clear(_writer);
   _artifacts->iterate_klasses(clear);
@@ -991,8 +1078,10 @@ static size_t teardown() {
   if (previous_epoch()) {
     clear_klasses_and_methods();
     JfrKlassUnloading::clear();
-    clear_artifacts = true;
+    _clear_artifacts = true;
     ++checkpoint_id;
+  } else {
+    _clear_artifacts = false;
   }
   return total_count;
 }
@@ -1005,12 +1094,11 @@ static void setup(JfrCheckpointWriter* writer, JfrCheckpointWriter* leakp_writer
   if (_artifacts == NULL) {
     _artifacts = new JfrArtifactSet(class_unload);
   } else {
-    _artifacts->initialize(class_unload, clear_artifacts);
+    _artifacts->initialize(class_unload, _clear_artifacts);
   }
   if (!_class_unload) {
     JfrKlassUnloading::sort(previous_epoch());
   }
-  clear_artifacts = false;
   assert(_artifacts != NULL, "invariant");
   assert(!_artifacts->has_klass_entries(), "invariant");
 }
@@ -1041,7 +1129,7 @@ size_t JfrTypeSet::serialize(JfrCheckpointWriter* writer, JfrCheckpointWriter* l
 void JfrTypeSet::clear() {
   ResourceMark rm;
   JfrKlassUnloading::clear();
-  clear_artifacts = true;
+  _clear_artifacts = true;
   setup(NULL, NULL, false, false);
   register_klasses();
   clear_packages();

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
@@ -52,7 +52,7 @@ static traceid atomic_inc(traceid volatile* const dest) {
 }
 
 static traceid next_class_id() {
-  static volatile traceid class_id_counter = LAST_TYPE_ID + 1;
+  static volatile traceid class_id_counter = LAST_TYPE_ID;
   return atomic_inc(&class_id_counter) << TRACE_ID_SHIFT;
 }
 
@@ -62,17 +62,17 @@ static traceid next_thread_id() {
 }
 
 static traceid next_module_id() {
-  static volatile traceid module_id_counter = 1;
+  static volatile traceid module_id_counter = 0;
   return atomic_inc(&module_id_counter) << TRACE_ID_SHIFT;
 }
 
 static traceid next_package_id() {
-  static volatile traceid package_id_counter = 1;
+  static volatile traceid package_id_counter = 0;
   return atomic_inc(&package_id_counter) << TRACE_ID_SHIFT;
 }
 
 static traceid next_class_loader_data_id() {
-  static volatile traceid cld_id_counter = 1;
+  static volatile traceid cld_id_counter = 0;
   return atomic_inc(&cld_id_counter) << TRACE_ID_SHIFT;
 }
 

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ static traceid atomic_inc(traceid volatile* const dest) {
 }
 
 static traceid next_class_id() {
-  static volatile traceid class_id_counter = LAST_TYPE_ID;
+  static volatile traceid class_id_counter = LAST_TYPE_ID + 1; // + 1 is for the void.class primitive
   return atomic_inc(&class_id_counter) << TRACE_ID_SHIFT;
 }
 
@@ -148,16 +148,44 @@ void JfrTraceId::assign(const ClassLoaderData* cld) {
   cld->set_trace_id(next_class_loader_data_id());
 }
 
+traceid JfrTraceId::assign_primitive_klass_id() {
+  return next_class_id();
+}
+
 traceid JfrTraceId::assign_thread_id() {
   return next_thread_id();
 }
 
-traceid JfrTraceId::load_raw(jclass jc) {
+// A mirror representing a primitive class (e.g. int.class) has no reified Klass*,
+// instead it has an associated TypeArrayKlass* (e.g. int[].class).
+// We can use the TypeArrayKlass* as a proxy for deriving the id of the primitive class.
+// The exception is the void.class, which has neither a Klass* nor a TypeArrayKlass*.
+// It will use a reserved constant.
+static traceid load_primitive(const oop mirror) {
+  assert(java_lang_Class::is_primitive(mirror), "invariant");
+  const Klass* const tak = java_lang_Class::array_klass_acquire(mirror);
+  traceid id;
+  if (tak == NULL) {
+    // The first klass id is reserved for the void.class
+    id = LAST_TYPE_ID + 1;
+  } else {
+    id = JfrTraceId::load_raw(tak) + 1;
+  }
+  JfrTraceIdEpoch::set_changed_tag_state();
+  return id;
+}
+
+traceid JfrTraceId::load(jclass jc, bool raw /* false */) {
   assert(jc != NULL, "invariant");
   assert(((JavaThread*)Thread::current())->thread_state() == _thread_in_vm, "invariant");
-  const oop my_oop = JNIHandles::resolve(jc);
-  assert(my_oop != NULL, "invariant");
-  return load_raw(java_lang_Class::as_Klass(my_oop));
+  const oop mirror = JNIHandles::resolve(jc);
+  assert(mirror != NULL, "invariant");
+  const Klass* const k = java_lang_Class::as_Klass(mirror);
+  return k != NULL ? (raw ? load_raw(k) : load(k)) : load_primitive(mirror);
+}
+
+traceid JfrTraceId::load_raw(jclass jc) {
+  return load(jc, true);
 }
 
 // used by CDS / APPCDS as part of "remove_unshareable_info"
@@ -186,6 +214,10 @@ void JfrTraceId::restore(const Klass* k) {
   const traceid event_flags = k->trace_id();
   // get a fresh traceid and restore the original event flags
   k->set_trace_id(next_class_id() | event_flags);
+  if (k->is_typeArray_klass()) {
+    // the next id is reserved for the corresponding primitive class
+    next_class_id();
+  }
 }
 
 bool JfrTraceId::in_visible_set(const jclass jc) {

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
@@ -83,11 +83,12 @@ class JfrTraceId : public AllStatic {
   static void assign(const ModuleEntry* module);
   static void assign(const PackageEntry* package);
   static void assign(const ClassLoaderData* cld);
+  static traceid assign_primitive_klass_id();
   static traceid assign_thread_id();
 
   // through load barrier
   static traceid load(const Klass* klass);
-  static traceid load(jclass jc);
+  static traceid load(jclass jc, bool raw = false);
   static traceid load(const Method* method);
   static traceid load(const Klass* klass, const Method* method);
   static traceid load(const ModuleEntry* module);

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,6 @@
 #include "oops/klass.hpp"
 #include "runtime/thread.inline.hpp"
 #include "utilities/debug.hpp"
-
-inline traceid JfrTraceId::load(jclass jc) {
-  return JfrTraceIdLoadBarrier::load(jc);
-}
 
 inline traceid JfrTraceId::load(const Klass* klass) {
   return JfrTraceIdLoadBarrier::load(klass);

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,10 @@
  */
 
 #include "precompiled.hpp"
-#include "classfile/javaClasses.inline.hpp"
 #include "jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.inline.hpp"
 #include "jfr/recorder/checkpoint/types/traceid/jfrTraceIdKlassQueue.hpp"
 #include "jfr/support/jfrThreadLocal.hpp"
 #include "jfr/utilities/jfrEpochQueue.inline.hpp"
-#include "runtime/jniHandles.inline.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/mutexLocker.hpp"
 
@@ -69,12 +67,4 @@ void JfrTraceIdLoadBarrier::enqueue(const Klass* klass) {
 void JfrTraceIdLoadBarrier::do_klasses(klass_callback callback, bool previous_epoch) {
   assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
   klass_queue().iterate(callback, previous_epoch);
-}
-
-traceid JfrTraceIdLoadBarrier::load(jclass jc) {
-  assert(jc != NULL, "invariant");
-  assert(((JavaThread*)Thread::current())->thread_state() == _thread_in_vm, "invariant");
-  const oop my_oop = JNIHandles::resolve(jc);
-  assert(my_oop != NULL, "invariant");
-  return load(java_lang_Class::as_Klass(my_oop));
 }

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 #ifndef SHARE_JFR_RECORDER_CHECKPOINT_TYPES_TRACEID_JFRTRACEIDLOADBARRIER_HPP
 #define SHARE_JFR_RECORDER_CHECKPOINT_TYPES_TRACEID_JFRTRACEIDLOADBARRIER_HPP
 
-#include "jni.h"
 #include "jfr/utilities/jfrTypes.hpp"
 #include "memory/allocation.hpp"
 
@@ -78,7 +77,6 @@ class JfrTraceIdLoadBarrier : AllStatic {
   static traceid load(const ClassLoaderData* cld);
   static traceid load(const Klass* klass);
   static traceid load(const Klass* klass, const Method* method);
-  static traceid load(jclass jc);
   static traceid load(const Method* method);
   static traceid load(const ModuleEntry* module);
   static traceid load(const PackageEntry* package);

--- a/src/hotspot/share/jfr/support/jfrTraceIdExtension.hpp
+++ b/src/hotspot/share/jfr/support/jfrTraceIdExtension.hpp
@@ -39,6 +39,7 @@
   static size_t trace_id_size() { return sizeof(traceid); }
 
 #define INIT_ID(data) JfrTraceId::assign(data)
+#define ASSIGN_PRIMITIVE_CLASS_ID(data) JfrTraceId::assign_primitive_klass_id()
 #define REMOVE_ID(k) JfrTraceId::remove(k);
 #define REMOVE_METHOD_ID(method) JfrTraceId::remove(method);
 #define RESTORE_ID(k) JfrTraceId::restore(k);

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -718,7 +718,7 @@
 #ifdef AARCH64
 
 #define VM_STRUCTS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field) \
-  static_field(VM_Version, _psr_info.dczid_el0, uint32_t)               \
+  static_field(VM_Version, _zva_length, int)                            \
   volatile_nonstatic_field(JavaFrameAnchor, _last_Java_fp, intptr_t*)
 
 #define VM_INT_CONSTANTS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant) \

--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -63,7 +63,7 @@ TypeArrayKlass* TypeArrayKlass::create_klass(BasicType type,
   // mirror creation fails, loaded_classes_do() doesn't find
   // an array class without a mirror.
   null_loader_data->add_class(ak);
-
+  JFR_ONLY(ASSIGN_PRIMITIVE_CLASS_ID(ak);)
   return ak;
 }
 

--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -748,7 +748,7 @@ public class JarFile extends ZipFile {
                 }
                 if (mev == null) {
                     mev = new ManifestEntryVerifier
-                        (getManifestFromReference());
+                        (getManifestFromReference(), jv.manifestName);
                 }
                 if (name.equalsIgnoreCase(MANIFEST_NAME)) {
                     b = jv.manifestRawBytes;

--- a/src/java.base/share/classes/java/util/jar/JarInputStream.java
+++ b/src/java.base/share/classes/java/util/jar/JarInputStream.java
@@ -95,7 +95,7 @@ public class JarInputStream extends ZipInputStream {
             closeEntry();
             if (doVerify) {
                 jv = new JarVerifier(e.getName(), bytes);
-                mev = new ManifestEntryVerifier(man);
+                mev = new ManifestEntryVerifier(man, jv.manifestName);
             }
             return (JarEntry)super.getNextEntry();
         }

--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -444,7 +444,7 @@ class JarVerifier {
         {
             this.is = Objects.requireNonNull(is);
             this.jv = jv;
-            this.mev = new ManifestEntryVerifier(man);
+            this.mev = new ManifestEntryVerifier(man, jv.manifestName);
             this.jv.beginEntry(je, mev);
             this.numLeft = je.getSize();
             if (this.numLeft == 0)

--- a/src/java.base/share/classes/sun/net/www/http/HttpClient.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpClient.java
@@ -303,7 +303,7 @@ public class HttpClient extends NetworkClient {
             ret = kac.get(url, null);
             if (ret != null && httpuc != null &&
                 httpuc.streaming() &&
-                httpuc.getRequestMethod() == "POST") {
+                "POST".equals(httpuc.getRequestMethod())) {
                 if (!ret.available()) {
                     ret.inCache = false;
                     ret.closeServer();

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -330,7 +330,7 @@ final class HttpsClient extends HttpClient
             ret = (HttpsClient) kac.get(url, sf);
             if (ret != null && httpuc != null &&
                 httpuc.streaming() &&
-                httpuc.getRequestMethod() == "POST") {
+                "POST".equals(httpuc.getRequestMethod())) {
                 if (!ret.available())
                     ret = null;
             }

--- a/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
+++ b/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,9 @@ public abstract class CalendarSystem {
         }
     }
 
-    private static final Gregorian GREGORIAN_INSTANCE = new Gregorian();
+    private static final class GregorianHolder {
+        private static final Gregorian GREGORIAN_INSTANCE = new Gregorian();
+    }
 
     /**
      * Returns the singleton instance of the <code>Gregorian</code>
@@ -120,7 +122,7 @@ public abstract class CalendarSystem {
      * @return the <code>Gregorian</code> instance
      */
     public static Gregorian getGregorianCalendar() {
-        return GREGORIAN_INSTANCE;
+        return GregorianHolder.GREGORIAN_INSTANCE;
     }
 
     /**
@@ -135,7 +137,7 @@ public abstract class CalendarSystem {
      */
     public static CalendarSystem forName(String calendarName) {
         if ("gregorian".equals(calendarName)) {
-            return GREGORIAN_INSTANCE;
+            return GregorianHolder.GREGORIAN_INSTANCE;
         }
 
         if (!initialized) {

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -569,7 +569,7 @@ public final class ZoneInfoFile {
                     // ZoneRulesBuilder adjusts < 0 case (-1, for last, don't have
                     // "<=" case yet) to positive value if not February (it appears
                     // we don't have February cutoff in tzdata table yet)
-                    // Ideally, if JSR310 can just pass in the nagative and
+                    // Ideally, if JSR310 can just pass in the negative and
                     // we can then pass in the dom = -1, dow > 0 into ZoneInfo
                     //
                     // hacking, assume the >=24 is the result of ZRB optimization for
@@ -889,12 +889,12 @@ public final class ZoneInfoFile {
     }
 
     // A simple/raw version of j.t.ZoneOffsetTransitionRule
+    // timeEndOfDay is included in secondOfDay as "86,400" secs.
     private static class ZoneOffsetTransitionRule {
         private final int month;
         private final byte dom;
         private final int dow;
         private final int secondOfDay;
-        private final boolean timeEndOfDay;
         private final int timeDefinition;
         private final int standardOffset;
         private final int offsetBefore;
@@ -912,7 +912,6 @@ public final class ZoneInfoFile {
             this.dom = (byte)(((data & (63 << 22)) >>> 22) - 32);
             this.dow = dowByte == 0 ? -1 : dowByte;
             this.secondOfDay = timeByte == 31 ? in.readInt() : timeByte * 3600;
-            this.timeEndOfDay = timeByte == 24;
             this.timeDefinition = (data & (3 << 12)) >>> 12;
 
             this.standardOffset = stdByte == 255 ? in.readInt() : (stdByte - 128) * 900;
@@ -932,9 +931,6 @@ public final class ZoneInfoFile {
                 if (dow != -1) {
                     epochDay = nextOrSame(epochDay, dow);
                 }
-            }
-            if (timeEndOfDay) {
-                epochDay += 1;
             }
             int difference = 0;
             switch (timeDefinition) {

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -600,9 +600,8 @@ public final class ZoneInfoFile {
                     params[7] = 0;
                 } else {
                     // hacking: see comment above
-                    if (dom < 0 || dom >= 24 &&
-                                   !(zoneId.equals("Asia/Gaza") ||
-                                     zoneId.equals("Asia/Hebron"))) {
+                    // No need of hacking for Asia/Gaza and Asia/Hebron from tz2021e
+                    if (dom < 0 || dom >= 24) {
                         params[6] = -1;
                         params[7] = toCalendarDOW[dow];
                     } else {

--- a/src/java.base/share/classes/sun/util/resources/TimeZoneNames.java
+++ b/src/java.base/share/classes/sun/util/resources/TimeZoneNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -353,7 +353,7 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -380,7 +380,9 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -569,9 +571,9 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville Time", "DDUT",
                                                         "Dumont-d'Urville Summer Time", "DDUST",
                                                         "Dumont-d'Urville Time", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Macquarie Island Standard Time", "MIST",
-                                                   "Macquarie Island Daylight Time", "MIDT",
-                                                   "Macquarie Island Time", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Mawson Time", "MAWT",
                                                 "Mawson Summer Time", "MAWST",
                                                 "Mawson Time", "MAWT"}},

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -444,7 +444,8 @@ static int copystrings(char *buf, int offset, const char * const *arg) {
 __attribute_noinline__
 #endif
 
-/* vfork(2) is deprecated on Solaris */
+/* vfork(2) is deprecated on Darwin */
+#ifndef __APPLE__
 static pid_t
 vforkChild(ChildStuff *c) {
     volatile pid_t resultPid;
@@ -463,6 +464,7 @@ vforkChild(ChildStuff *c) {
     assert(resultPid != 0);  /* childProcess never returns */
     return resultPid;
 }
+#endif
 
 static pid_t
 forkChild(ChildStuff *c) {
@@ -573,9 +575,11 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
 static pid_t
 startChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) {
     switch (c->mode) {
-/* vfork(2) is deprecated on Solaris */
+/* vfork(2) is deprecated on Darwin*/
+      #ifndef __APPLE__
       case MODE_VFORK:
         return vforkChild(c);
+      #endif
       case MODE_FORK:
         return forkChild(c);
       case MODE_POSIX_SPAWN:

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -464,6 +464,9 @@ public final class LWCToolkit extends LWToolkit {
 
     @Override
     protected boolean syncNativeQueue(long timeout) {
+        if (timeout <= 0) {
+            return false;
+        }
         if (SunDragSourceContextPeer.isDragDropInProgress()
                 || EventQueue.isDispatchThread()) {
             // The java code started the DnD, but the native drag may still not

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -323,7 +323,7 @@ public class TIFFIFD extends TIFFDirectory {
                         while (bytesToRead != 0) {
                             int sz = Math.min(bytesToRead, UNIT_SIZE);
                             byte[] unit = new byte[sz];
-                            stream.readFully(unit, bytesRead, sz);
+                            stream.readFully(unit, 0, sz);
                             bufs.add(unit);
                             bytesRead += sz;
                             bytesToRead -= sz;
@@ -459,7 +459,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (shortsToRead != 0) {
                         int sz = Math.min(shortsToRead, SSHORT_TILE_SIZE);
                         short[] unit = new short[sz];
-                        stream.readFully(unit, shortsRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         shortsRead += sz;
                         shortsToRead -= sz;
@@ -490,7 +490,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (intsToRead != 0) {
                         int sz = Math.min(intsToRead, INT_TILE_SIZE);
                         int[] unit = new int[sz];
-                        stream.readFully(unit, intsToRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         intsRead += sz;
                         intsToRead -= sz;
@@ -522,7 +522,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (srationalsToRead != 0) {
                         int sz = Math.min(srationalsToRead, SRATIONAL_TILE_SIZE);
                         int[] unit = new int[sz * 2];
-                        stream.readFully(unit, (srationalsToRead * 2), (sz * 2));
+                        stream.readFully(unit, 0, (sz * 2));
                         bufs.add(unit);
                         srationalsRead += sz;
                         srationalsToRead -= sz;
@@ -556,7 +556,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (floatsToRead != 0) {
                         int sz = Math.min(floatsToRead, FLOAT_TILE_SIZE);
                         float[] unit = new float[sz];
-                        stream.readFully(unit, floatsToRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         floatsRead += sz;
                         floatsToRead -= sz;
@@ -587,7 +587,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (doublesToRead != 0) {
                         int sz = Math.min(doublesToRead, DOUBLE_TILE_SIZE);
                         double[] unit = new double[sz];
-                        stream.readFully(unit, doublesToRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         doublesRead += sz;
                         doublesToRead -= sz;

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,40 @@
 
 package sun.awt;
 
-import java.awt.*;
+import java.awt.AWTEvent;
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.Canvas;
+import java.awt.Checkbox;
+import java.awt.Choice;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.DefaultKeyboardFocusManager;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FocusTraversalPolicy;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
+import java.awt.Image;
+import java.awt.KeyboardFocusManager;
+import java.awt.Label;
+import java.awt.MenuComponent;
+import java.awt.Panel;
+import java.awt.RenderingHints;
+import java.awt.ScrollPane;
+import java.awt.Scrollbar;
+import java.awt.SystemTray;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.Toolkit;
+import java.awt.TrayIcon;
+import java.awt.Window;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
@@ -35,10 +68,10 @@ import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
 import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
+import java.awt.image.MultiResolutionImage;
 import java.awt.image.Raster;
 import java.awt.peer.FramePeer;
 import java.awt.peer.KeyboardFocusManagerPeer;
-import java.awt.peer.MouseInfoPeer;
 import java.awt.peer.SystemTrayPeer;
 import java.awt.peer.TrayIconPeer;
 import java.io.File;
@@ -55,6 +88,7 @@ import java.util.Map;
 import java.util.Vector;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -62,7 +96,6 @@ import sun.awt.im.InputContext;
 import sun.awt.image.ByteArrayImageSource;
 import sun.awt.image.FileImageSource;
 import sun.awt.image.ImageRepresentation;
-import java.awt.image.MultiResolutionImage;
 import sun.awt.image.MultiResolutionToolkitImage;
 import sun.awt.image.ToolkitImage;
 import sun.awt.image.URLImageSource;
@@ -72,7 +105,13 @@ import sun.security.action.GetBooleanAction;
 import sun.security.action.GetPropertyAction;
 import sun.util.logging.PlatformLogger;
 
-import static java.awt.RenderingHints.*;
+import static java.awt.RenderingHints.KEY_TEXT_ANTIALIASING;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_GASP;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HBGR;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_VBGR;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_VRGB;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
 
 public abstract class SunToolkit extends Toolkit
     implements ComponentFactory, InputMethodSupport, KeyboardFocusManagerPeerProvider {
@@ -1378,10 +1417,6 @@ public abstract class SunToolkit extends Toolkit
     }
 
     @SuppressWarnings("serial")
-    public static class InfiniteLoop extends RuntimeException {
-    }
-
-    @SuppressWarnings("serial")
     public static class IllegalThreadException extends RuntimeException {
         public IllegalThreadException(String msg) {
             super(msg);
@@ -1391,14 +1426,14 @@ public abstract class SunToolkit extends Toolkit
     }
 
     public static final int DEFAULT_WAIT_TIME = 10000;
-    private static final int MAX_ITERS = 20;
-    private static final int MIN_ITERS = 0;
-    private static final int MINIMAL_EDELAY = 0;
+    private static final int MAX_ITERS = 100;
+    private static final int MIN_ITERS = 1;
+    private static final int MINIMAL_DELAY = 5;
 
     /**
      * Parameterless version of realsync which uses default timout (see DEFAUL_WAIT_TIME).
      */
-    public void realSync() throws OperationTimedOut, InfiniteLoop {
+    public void realSync() throws OperationTimedOut {
         realSync(DEFAULT_WAIT_TIME);
     }
 
@@ -1447,13 +1482,21 @@ public abstract class SunToolkit extends Toolkit
      *
      * @param timeout the maximum time to wait in milliseconds, negative means "forever".
      */
-    public void realSync(final long timeout) throws OperationTimedOut, InfiniteLoop
-    {
+    public void realSync(final long timeout) throws OperationTimedOut {
         if (EventQueue.isDispatchThread()) {
             throw new IllegalThreadException("The SunToolkit.realSync() method cannot be used on the event dispatch thread (EDT).");
         }
+        try {
+            // We should wait unconditionally for the first event on EDT
+            EventQueue.invokeAndWait(() -> {/*dummy implementation*/});
+        } catch (InterruptedException | InvocationTargetException ignored) {
+        }
         int bigLoop = 0;
+        long end = TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) + timeout;
         do {
+            if (timeout(end) < 0) {
+                return;
+            }
             // Let's do sync first
             sync();
 
@@ -1464,14 +1507,11 @@ public abstract class SunToolkit extends Toolkit
             // to dispatch.
             int iters = 0;
             while (iters < MIN_ITERS) {
-                syncNativeQueue(timeout);
+                syncNativeQueue(timeout(end));
                 iters++;
             }
-            while (syncNativeQueue(timeout) && iters < MAX_ITERS) {
+            while (syncNativeQueue(timeout(end)) && iters < MAX_ITERS) {
                 iters++;
-            }
-            if (iters >= MAX_ITERS) {
-                throw new InfiniteLoop();
             }
 
             // native requests were dispatched by X/Window Manager or Windows
@@ -1483,21 +1523,23 @@ public abstract class SunToolkit extends Toolkit
             // waitForIdle, we may end up with full EventQueue
             iters = 0;
             while (iters < MIN_ITERS) {
-                waitForIdle(timeout);
+                waitForIdle(timeout(end));
                 iters++;
             }
-            while (waitForIdle(timeout) && iters < MAX_ITERS) {
+            while (waitForIdle(end) && iters < MAX_ITERS) {
                 iters++;
-            }
-            if (iters >= MAX_ITERS) {
-                throw new InfiniteLoop();
             }
 
             bigLoop++;
             // Again, for Java events, it was simple to check for new Java
             // events by checking event queue, but what if Java events
             // resulted in native requests?  Therefor, check native events again.
-        } while ((syncNativeQueue(timeout) || waitForIdle(timeout)) && bigLoop < MAX_ITERS);
+        } while ((syncNativeQueue(timeout(end)) || waitForIdle(end))
+                && bigLoop < MAX_ITERS);
+    }
+
+    private long timeout(long end){
+        return end - TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
     }
 
     /**
@@ -1508,10 +1550,8 @@ public abstract class SunToolkit extends Toolkit
      * {@code true} if some events were processed,
      * {@code false} otherwise.
      */
-    protected abstract boolean syncNativeQueue(final long timeout);
+    protected abstract boolean syncNativeQueue(long timeout);
 
-    private boolean eventDispatched;
-    private boolean queueEmpty;
     private final Object waitLock = new Object();
 
     private boolean isEQEmpty() {
@@ -1527,13 +1567,13 @@ public abstract class SunToolkit extends Toolkit
      * necessary, {@code false} otherwise.
      */
     @SuppressWarnings("serial")
-    protected final boolean waitForIdle(final long timeout) {
+    private final boolean waitForIdle(final long end) {
         flushPendingEvents();
         final boolean queueWasEmpty;
+        final AtomicBoolean queueEmpty = new AtomicBoolean();
+        final AtomicBoolean eventDispatched = new AtomicBoolean();
         synchronized (waitLock) {
             queueWasEmpty = isEQEmpty();
-            queueEmpty = false;
-            eventDispatched = false;
             postEvent(AppContext.getAppContext(),
                       new PeerEvent(getSystemEventQueueImpl(), null, PeerEvent.LOW_PRIORITY_EVENT) {
                           @Override
@@ -1545,24 +1585,24 @@ public abstract class SunToolkit extends Toolkit
                               // flush Java events again.
                               int iters = 0;
                               while (iters < MIN_ITERS) {
-                                  syncNativeQueue(timeout);
+                                  syncNativeQueue(timeout(end));
                                   iters++;
                               }
-                              while (syncNativeQueue(timeout) && iters < MAX_ITERS) {
+                              while (syncNativeQueue(timeout(end)) && iters < MAX_ITERS) {
                                   iters++;
                               }
                               flushPendingEvents();
 
                               synchronized(waitLock) {
-                                  queueEmpty = isEQEmpty();
-                                  eventDispatched = true;
+                                  queueEmpty.set(isEQEmpty());
+                                  eventDispatched.set(true);
                                   waitLock.notifyAll();
                               }
                           }
                       });
             try {
-                while (!eventDispatched) {
-                    waitLock.wait();
+                while (!eventDispatched.get() && timeout(end) > 0) {
+                    waitLock.wait(timeout(end));
                 }
             } catch (InterruptedException ie) {
                 return false;
@@ -1570,7 +1610,7 @@ public abstract class SunToolkit extends Toolkit
         }
 
         try {
-            Thread.sleep(MINIMAL_EDELAY);
+            Thread.sleep(MINIMAL_DELAY);
         } catch (InterruptedException ie) {
             throw new RuntimeException("Interrupted");
         }
@@ -1579,7 +1619,7 @@ public abstract class SunToolkit extends Toolkit
 
         // Lock to force write-cache flush for queueEmpty.
         synchronized (waitLock) {
-            return !(queueEmpty && isEQEmpty() && queueWasEmpty);
+            return !(queueEmpty.get() && isEQEmpty() && queueWasEmpty);
         }
     }
 

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1408,15 +1408,6 @@ public abstract class SunToolkit extends Toolkit
     }
 
     @SuppressWarnings("serial")
-    public static class OperationTimedOut extends RuntimeException {
-        public OperationTimedOut(String msg) {
-            super(msg);
-        }
-        public OperationTimedOut() {
-        }
-    }
-
-    @SuppressWarnings("serial")
     public static class IllegalThreadException extends RuntimeException {
         public IllegalThreadException(String msg) {
             super(msg);
@@ -1433,7 +1424,7 @@ public abstract class SunToolkit extends Toolkit
     /**
      * Parameterless version of realsync which uses default timout (see DEFAUL_WAIT_TIME).
      */
-    public void realSync() throws OperationTimedOut {
+    public void realSync() {
         realSync(DEFAULT_WAIT_TIME);
     }
 
@@ -1482,7 +1473,7 @@ public abstract class SunToolkit extends Toolkit
      *
      * @param timeout the maximum time to wait in milliseconds, negative means "forever".
      */
-    public void realSync(final long timeout) throws OperationTimedOut {
+    public void realSync(final long timeout) {
         if (EventQueue.isDispatchThread()) {
             throw new IllegalThreadException("The SunToolkit.realSync() method cannot be used on the event dispatch thread (EDT).");
         }
@@ -1538,7 +1529,7 @@ public abstract class SunToolkit extends Toolkit
                 && bigLoop < MAX_ITERS);
     }
 
-    private long timeout(long end){
+    protected long timeout(long end){
         return end - TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
     }
 
@@ -1568,6 +1559,9 @@ public abstract class SunToolkit extends Toolkit
      */
     @SuppressWarnings("serial")
     private final boolean waitForIdle(final long end) {
+        if (timeout(end) <= 0) {
+            return false;
+        }
         flushPendingEvents();
         final boolean queueWasEmpty;
         final AtomicBoolean queueEmpty = new AtomicBoolean();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -2589,6 +2589,9 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
      */
     @Override
     protected boolean syncNativeQueue(final long timeout) {
+        if (timeout <= 0) {
+            return false;
+        }
         XBaseWindow win = XBaseWindow.getXAWTRootWindow();
 
         if (oops_waiter == null) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -125,6 +125,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.Vector;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.LookAndFeel;
 import javax.swing.UIDefaults;
@@ -2588,7 +2589,7 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
      * @inheritDoc
      */
     @Override
-    protected boolean syncNativeQueue(final long timeout) {
+    protected boolean syncNativeQueue(long timeout) {
         if (timeout <= 0) {
             return false;
         }
@@ -2613,30 +2614,32 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
 
             oops_updated = false;
             long event_number = getEventNumber();
-            // Generate OOPS ConfigureNotify event
-            XlibWrapper.XMoveWindow(getDisplay(), win.getWindow(),
-                                    win.scaleUp(++oops_position), 0);
             // Change win position each time to avoid system optimization
+            oops_position += 5;
             if (oops_position > 50) {
                 oops_position = 0;
             }
+            // Generate OOPS ConfigureNotify event
+            XlibWrapper.XMoveWindow(getDisplay(), win.getWindow(),
+                                    oops_position, 0);
 
             XSync();
 
             eventLog.finer("Generated OOPS ConfigureNotify event");
 
-            long start = System.currentTimeMillis();
+            long end = TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) + timeout;
+            // This "while" is a protection from spurious wake-ups.
+            // However, we shouldn't wait for too long.
             while (!oops_updated) {
+                timeout = timeout(end);
+                if (timeout <= 0) {
+                    break;
+                }
                 try {
                     // Wait for OOPS ConfigureNotify event
                     awtLockWait(timeout);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
-                }
-                // This "while" is a protection from spurious
-                // wake-ups.  However, we shouldn't wait for too long
-                if ((System.currentTimeMillis() - start > timeout) && timeout >= 0) {
-                    throw new OperationTimedOut(Long.toString(System.currentTimeMillis() - start));
                 }
             }
             // Don't take into account OOPS ConfigureNotify event

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -1234,7 +1234,7 @@ public final class WToolkit extends SunToolkit implements Runnable {
     ///////////////////////////////////////////////////////////////////////////
 
     @Override
-    public native boolean syncNativeQueue(final long timeout);
+    public native boolean syncNativeQueue(long timeout);
 
     @Override
     public boolean isDesktopSupported() {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -3008,6 +3008,9 @@ Java_sun_awt_windows_WToolkit_hideTouchKeyboard(JNIEnv *env, jobject self)
 JNIEXPORT jboolean JNICALL
 Java_sun_awt_windows_WToolkit_syncNativeQueue(JNIEnv *env, jobject self, jlong timeout)
 {
+    if (timeout <= 0) {
+        return JNI_FALSE;
+    }
     AwtToolkit & tk = AwtToolkit::GetInstance();
     DWORD eventNumber = tk.eventNumber;
     tk.PostMessage(WM_SYNC_WAIT, 0, 0);

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -705,7 +705,10 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     // ARMv8-A architecture reference manual D12.2.35 Data Cache Zero ID register says:
     // * BS, bits [3:0] indicate log2 of the DC ZVA block size in (4-byte) words.
     // * DZP, bit [4] of indicates whether use of DC ZVA instruction is prohibited.
-    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10, (JVMCI ? jvmciGE(JVMCI_19_3_b04) : JDK >= 14) && osArch.equals("aarch64"));
+    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10,
+                    (JVMCI ? jvmciGE(JVMCI_19_3_b04) : (JDK == 14 || JDK == 15)) && osArch.equals("aarch64"));
+
+    public final int zvaLength = getFieldValue("VM_Version::_zva_length", Integer.class, "int", 0, JDK >= 16 && osArch.equals("aarch64"));
 
     // FIXME This is only temporary until the GC code is changed.
     public final boolean inlineContiguousAllocationSupported = getFieldValue("CompilerToVM::Data::_supports_inline_contig_alloc", Boolean.class);

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_de.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_de.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville Zeit", "DDUT",
                                                         "Dumont-d'Urville Sommerzeit", "DDUST",
                                                         "Dumont-d'Urville Zeit", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Macquarieinsel Zeit", "MIST",
-                                                   "Macquarieinsel Sommerzeit", "MIST",
-                                                   "Macquarieinsel Zeit", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Mawson Zeit", "MAWT",
                                                 "Mawson Sommerzeit", "MAWST",
                                                 "Mawson Zeit", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_es.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_es.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Hora de Dumont-d'Urville", "DDUT",
                                                         "Hora de verano de Dumont-d'Urville", "DDUST",
                                                         "Hora de Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Hora de Isla Macquarie", "MIST",
-                                                   "Hora de verano de Isla Macquarie", "MIST",
-                                                   "Hora de Isla Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Hora de Mawson", "MAWT",
                                                 "Hora de verano de Mawson", "MAWST",
                                                 "Hora de Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_fr.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_fr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Heure de Dumont-d'Urville", "DDUT",
                                                         "Heure d'\u00e9t\u00e9 de Dumont-d'Urville", "DDUST",
                                                         "Heure de Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Heure de l'Ile Macquarie", "MIST",
-                                                   "Heure d'\u00E9t\u00E9 de l'Ile Macquarie", "MIST",
-                                                   "Heure de l'Ile Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Heure de Mawson", "MAWT",
                                                 "Heure d'\u00e9t\u00e9 de Mawson", "MAWST",
                                                 "Heure de Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_it.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_it.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Ora di Dumont-d'Urville", "DDUT",
                                                         "Ora estiva di Dumont-d'Urville", "DDUST",
                                                         "Ora di Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Ora dell'Isola Macquarie", "MIST",
-                                                   "Ora estiva dell'Isola Macquarie", "MIST",
-                                                   "Ora dell'Isola Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Ora di Mawson", "MAWT",
                                                 "Ora estiva di Mawson", "MAWST",
                                                 "Ora di Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ja.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ja.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"\u30c7\u30e5\u30e2\u30f3\u30c7\u30e5\u30eb\u30f4\u30a3\u30eb\u6642\u9593", "DDUT",
                                                         "\u30c7\u30e5\u30e2\u30f3\u30c7\u30e5\u30eb\u30f4\u30a3\u30eb\u590f\u6642\u9593", "DDUST",
                                                         "\u30C7\u30E5\u30E2\u30F3\u30FB\u30C7\u30E5\u30EB\u30D3\u30EB\u6642\u9593", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\u30DE\u30C3\u30B3\u30FC\u30EA\u30FC\u5CF6\u6642\u9593", "MIST",
-                                                   "\u30DE\u30C3\u30B3\u30FC\u30EA\u30FC\u5CF6\u590F\u6642\u9593", "MIST",
-                                                   "\u30DE\u30C3\u30B3\u30FC\u30EA\u30FC\u5CF6\u6642\u9593", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\u30e2\u30fc\u30bd\u30f3\u6642\u9593", "MAWT",
                                                 "\u30e2\u30fc\u30bd\u30f3\u590f\u6642\u9593", "MAWST",
                                                 "\u30E2\u30FC\u30BD\u30F3\u6642\u9593", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ko.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ko.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"\ub4a4\ubabd \ub4a4\ub974\ube4c \uc2dc\uac04", "DDUT",
                                                         "\ub4a4\ubabd \ub4a4\ub974\ube4c \uc77c\uad11\uc808\uc57d\uc2dc\uac04", "DDUST",
                                                         "\uB450\uBAAC\uD2B8\uC6B0\uB974\uBE4C \uD45C\uC900\uC2DC", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\uB9E4\uCF70\uB9AC \uC12C \uD45C\uC900\uC2DC", "MIST",
-                                                   "\uB9E4\uCF70\uB9AC \uC12C \uC77C\uAD11 \uC808\uC57D \uC2DC\uAC04", "MIST",
-                                                   "\uB9E4\uCF70\uB9AC \uC12C \uD45C\uC900\uC2DC", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\ubaa8\uc2a8 \uc2dc\uac04", "MAWT",
                                                 "\ubaa8\uc2a8 \uc77c\uad11\uc808\uc57d\uc2dc\uac04", "MAWST",
                                                 "\uB9C8\uC2A8 \uD45C\uC900\uC2DC", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_pt_BR.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_pt_BR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Fuso hor\u00e1rio de Dumont-d'Urville", "DDUT",
                                                         "Fuso hor\u00e1rio de ver\u00e3o de Dumont-d'Urville", "DDUST",
                                                         "Fuso Hor\u00E1rio de Dumont-d'Urville", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Fuso Hor\u00E1rio da Ilha de Macquarie", "MIST",
-                                                   "Fuso Hor\u00E1rio de Ver\u00E3o da Ilha de Macquarie", "MIST",
-                                                   "Fuso Hor\u00E1rio da Ilha de Macquarie", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Fuso hor\u00e1rio de Mawson", "MAWT",
                                                 "Fuso hor\u00e1rio de ver\u00e3o de Mawson", "MAWST",
                                                 "Hor\u00E1rio de Mawson", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_sv.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_sv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville, normaltid", "DDUT",
                                                         "Dumont-d'Urville, sommartid", "DDUST",
                                                         "Dumont-d'Urville-tid", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"Macquarie\u00F6n, normaltid", "MIST",
-                                                   "Macquarie\u00F6n, sommartid", "MIST",
-                                                   "Macquarie\u00F6n, normaltid", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"Mawson, normaltid", "MAWT",
                                                 "Mawson, sommartid", "MAWST",
                                                 "Mawson-tid", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_CN.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_CN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville \u65f6\u95f4", "DDUT",
                                                         "Dumont-d'Urville \u590f\u4ee4\u65f6", "DDUST",
                                                         "Dumont-d'Urville \u65F6\u95F4", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\u9EA6\u5938\u91CC\u5C9B\u65F6\u95F4", "MIST",
-                                                   "\u9EA6\u5938\u91CC\u5C9B\u590F\u4EE4\u65F6", "MIST",
-                                                   "\u9EA6\u5938\u91CC\u5C9B\u65F6\u95F4", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\u83ab\u68ee\u65f6\u95f4", "MAWT",
                                                 "\u83ab\u68ee\u590f\u4ee4\u65f6", "MAWST",
                                                 "\u83AB\u68EE\u65F6\u95F4", "MAWT"}},

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_TW.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_TW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
             {"Africa/Gaborone", CAT},
             {"Africa/Harare", CAT},
             {"Africa/Johannesburg", SAST},
-            {"Africa/Juba", EAT},
+            {"Africa/Juba", CAT},
             {"Africa/Kampala", EAT},
             {"Africa/Khartoum", CAT},
             {"Africa/Kigali", CAT},
@@ -378,7 +378,9 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
             {"Africa/Timbuktu", GMT},
             {"Africa/Tripoli", EET},
             {"Africa/Tunis", CET},
-            {"Africa/Windhoek", CAT},
+            {"Africa/Windhoek", new String[] {"Central African Time", "CAT",
+                                              "Western African Time", "WAT",
+                                              "Central African Time", "CAT"}},
             {"America/Adak", HST},
             {"America/Anguilla", AST},
             {"America/Antigua", AST},
@@ -564,9 +566,9 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
             {"Antarctica/DumontDUrville", new String[] {"Dumont-d'Urville \u6642\u9593", "DDUT",
                                                         "Dumont-d'Urville \u590f\u4ee4\u6642\u9593", "DDUST",
                                                         "Dumont-d'Urville \u6642\u9593", "DDUT"}},
-            {"Antarctica/Macquarie", new String[] {"\u9EA5\u5938\u5229\u5CF6\u6642\u9593", "MIST",
-                                                   "\u9EA5\u5938\u5229\u5CF6\u590F\u4EE4\u6642\u9593", "MIST",
-                                                   "\u9EA5\u5938\u5229\u5CF6\u6642\u9593", "MIST"}},
+            {"Antarctica/Macquarie", new String[] {"Australian Eastern Standard Time (Macquarie)", "AEST",
+                                                   "Australian Eastern Daylight Time (Macquarie)", "AEDT",
+                                                   "Australian Eastern Time (Macquarie)", "AET"}},
             {"Antarctica/Mawson", new String[] {"\u83ab\u68ee\u6642\u9593", "MAWT",
                                                 "\u83ab\u68ee\u590f\u4ee4\u6642\u9593", "MAWST",
                                                 "\u83AB\u68EE\u6642\u9593", "MAWT"}},

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -118,6 +118,11 @@ class ZipFileSystem extends FileSystem {
     private final boolean noExtt;        // see readExtra()
     private final boolean useTempFile;   // use a temp file for newOS, default
                                          // is to use BAOS for better performance
+
+    // a threshold, in bytes, to decide whether to create a temp file
+    // for outputstream of a zip entry
+    private final int tempFileCreationThreshold = 10 * 1024 * 1024; // 10 MB
+
     private final boolean forceEnd64;
     private final int defaultCompressionMethod; // METHOD_STORED if "noCompression=true"
                                                 // METHOD_DEFLATED otherwise
@@ -1935,11 +1940,11 @@ class ZipFileSystem extends FileSystem {
         if (zc.isUTF8())
             e.flag |= FLAG_USE_UTF8;
         OutputStream os;
-        if (useTempFile) {
+        if (useTempFile || e.size >= tempFileCreationThreshold) {
             e.file = getTempPathForEntry(null);
             os = Files.newOutputStream(e.file, WRITE);
         } else {
-            os = new ByteArrayOutputStream((e.size > 0)? (int)e.size : 8192);
+            os = new FileRolloverOutputStream(e);
         }
         if (e.method == METHOD_DEFLATED) {
             return new DeflatingEntryOutputStream(e, os);
@@ -1979,8 +1984,12 @@ class ZipFileSystem extends FileSystem {
             }
             isClosed = true;
             e.size = written;
-            if (out instanceof ByteArrayOutputStream)
-                e.bytes = ((ByteArrayOutputStream)out).toByteArray();
+            if (out instanceof FileRolloverOutputStream) {
+                FileRolloverOutputStream fros = (FileRolloverOutputStream)out;
+                if (fros.tmpFileOS == null) {
+                    e.bytes = fros.toByteArray();
+                }
+            }
             super.close();
             update(e);
         }
@@ -2015,8 +2024,12 @@ class ZipFileSystem extends FileSystem {
             e.size  = def.getBytesRead();
             e.csize = def.getBytesWritten();
             e.crc = crc.getValue();
-            if (out instanceof ByteArrayOutputStream)
-                e.bytes = ((ByteArrayOutputStream)out).toByteArray();
+            if (out instanceof FileRolloverOutputStream) {
+                FileRolloverOutputStream fros = (FileRolloverOutputStream)out;
+                if (fros.tmpFileOS == null) {
+                    e.bytes = fros.toByteArray();
+                }
+            }
             super.close();
             update(e);
             releaseDeflater(def);
@@ -2095,6 +2108,111 @@ class ZipFileSystem extends FileSystem {
             e.csize = def.getBytesWritten();
             e.crc = crc.getValue();
             releaseDeflater(def);
+        }
+    }
+
+    // A wrapper around the ByteArrayOutputStream. This FileRolloverOutputStream
+    // uses a threshold size to decide if the contents being written need to be
+    // rolled over into a temporary file. Until the threshold is reached, writes
+    // on this outputstream just write it to the internal in-memory byte array
+    // held by the ByteArrayOutputStream. Once the threshold is reached, the
+    // write operation on this outputstream first (and only once) creates a temporary file
+    // and transfers the data that has so far been written in the internal
+    // byte array, to that newly created file. The temp file is then opened
+    // in append mode and any subsequent writes, including the one which triggered
+    // the temporary file creation, will be written to the file.
+    // Implementation note: the "write" and the "close" methods of this implementation
+    // aren't "synchronized" because this FileRolloverOutputStream gets called
+    // only from either DeflatingEntryOutputStream or EntryOutputStream, both of which
+    // already have the necessary "synchronized" before calling these methods.
+    private class FileRolloverOutputStream extends OutputStream {
+        private ByteArrayOutputStream baos = new ByteArrayOutputStream(8192);
+        private final Entry entry;
+        private OutputStream tmpFileOS;
+        private long totalWritten = 0;
+
+        private FileRolloverOutputStream(final Entry e) {
+            this.entry = e;
+        }
+
+        @Override
+        public void write(final int b) throws IOException {
+            if (tmpFileOS != null) {
+                // already rolled over, write to the file that has been created previously
+                writeToFile(b);
+                return;
+            }
+            if (totalWritten + 1 < tempFileCreationThreshold) {
+                // write to our in-memory byte array
+                baos.write(b);
+                totalWritten++;
+                return;
+            }
+            // rollover into a file
+            transferToFile();
+            writeToFile(b);
+        }
+
+        @Override
+        public void write(final byte[] b) throws IOException {
+            write(b, 0, b.length);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len) throws IOException {
+            if (tmpFileOS != null) {
+                // already rolled over, write to the file that has been created previously
+                writeToFile(b, off, len);
+                return;
+            }
+            if (totalWritten + len < tempFileCreationThreshold) {
+                // write to our in-memory byte array
+                baos.write(b, off, len);
+                totalWritten += len;
+                return;
+            }
+            // rollover into a file
+            transferToFile();
+            writeToFile(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            if (tmpFileOS != null) {
+                tmpFileOS.flush();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            baos = null;
+            if (tmpFileOS != null) {
+                tmpFileOS.close();
+            }
+        }
+
+        private void writeToFile(int b) throws IOException {
+            tmpFileOS.write(b);
+            totalWritten++;
+        }
+
+        private void writeToFile(byte[] b, int off, int len) throws IOException {
+            tmpFileOS.write(b, off, len);
+            totalWritten += len;
+        }
+
+        private void transferToFile() throws IOException {
+            // create a tempfile
+            entry.file = getTempPathForEntry(null);
+            tmpFileOS = new BufferedOutputStream(Files.newOutputStream(entry.file));
+            // transfer the already written data from the byte array buffer into this tempfile
+            baos.writeTo(tmpFileOS);
+            // release the underlying byte array
+            baos = null;
+        }
+
+        private byte[] toByteArray() {
+            return baos == null ? null : baos.toByteArray();
         }
     }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -772,7 +772,6 @@ javax/swing/plaf/basic/Test6984643.java 8198340 windows-all
 javax/swing/text/CSSBorder/6796710/bug6796710.java 8196099 windows-all
 javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 windows-all
 javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 linux-all
-javax/swing/text/JTextComponent/5074573/bug5074573.java 8196100 windows-all
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all

--- a/test/jdk/java/awt/Robot/FlushCurrentEvent.java
+++ b/test/jdk/java/awt/Robot/FlushCurrentEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Robot;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @test
+ * @key headful
+ * @bug 8196100
+ * @summary Checks that current event is flushed by the Robot.waitForIdle()
+ */
+public final class FlushCurrentEvent {
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        AtomicBoolean done = new AtomicBoolean();
+        EventQueue.invokeLater(() -> {
+            robot.delay(15000);
+            done.set(true);
+        });
+        robot.waitForIdle();
+        if (!done.get()) {
+            throw new RuntimeException("Current event was not flushed");
+        }
+    }
+}

--- a/test/jdk/java/awt/Robot/InfiniteLoopException.java
+++ b/test/jdk/java/awt/Robot/InfiniteLoopException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Robot;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @test
+ * @key headful
+ * @bug 8196100
+ * @summary Checks that Robot.waitForIdle() works if EDT is overloaded
+ */
+public final class InfiniteLoopException {
+
+    public static void main(String[] args) throws Exception {
+        Frame frame = new Frame();
+        try {
+            frame.setSize(300, 300);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+            test(frame);
+        } finally {
+            frame.dispose();
+        }
+    }
+
+    private static void test(Frame frame) throws Exception {
+        Runnable repaint = () -> {
+            while (frame.isDisplayable()) {
+                frame.repaint();
+            }
+        };
+        new Thread(repaint).start();
+        new Thread(repaint).start();
+        new Thread(repaint).start();
+
+        Robot robot = new Robot();
+        long start = System.nanoTime();
+        robot.waitForIdle();
+        long time = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start);
+        if (time > 20) {
+            throw new RuntimeException("Too slow:" + time);
+        }
+    }
+}

--- a/test/jdk/java/util/TimeZone/TimeZoneTest.java
+++ b/test/jdk/java/util/TimeZone/TimeZoneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 4028006 4044013 4096694 4107276 4107570 4112869 4130885 7039469 7126465 7158483
  *      8008577 8077685 8098547 8133321 8138716 8148446 8151876 8159684 8166875 8181157
- *      8228469
+ *      8228469 8274407
  * @modules java.base/sun.util.resources
  * @library /java/text/testlib
  * @summary test TimeZone
@@ -102,7 +102,7 @@ public class TimeZoneTest extends IntlTest
     public void TestShortZoneIDs() throws Exception {
 
         ZoneDescriptor[] JDK_116_REFERENCE_LIST = {
-            new ZoneDescriptor("MIT", 780, true),
+            new ZoneDescriptor("MIT", 780, false), // Samoa no longer observes DST starting 2021b
             new ZoneDescriptor("HST", -600, false),
             new ZoneDescriptor("AST", -540, true),
             new ZoneDescriptor("PST", -480, true),

--- a/test/jdk/javax/imageio/plugins/tiff/LargeTIFFTagTest.java
+++ b/test/jdk/javax/imageio/plugins/tiff/LargeTIFFTagTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8270893
+ * @summary Ensure that we don't throw IndexOutOfBoundsException when
+ *          we read TIFF tag with content more than 1024000 bytes
+ * @run main LargeTIFFTagTest
+ */
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Iterator;
+
+public class LargeTIFFTagTest {
+    public static void main(String[] args) throws IOException {
+        // TIFF stream length to hold 22 bytes of TIFF header
+        // plus 1024002 bytes of data in one TIFFTag
+        int length = 1024024;
+        byte[] ba = new byte[length];
+        // Little endian TIFF stream with header and only one
+        // IFD entry at offset 22 having count value 1024002.
+        byte[] header = new byte[] { (byte)0x49, (byte) 0x49,
+                (byte)0x2a, (byte)0x00, (byte)0x08, (byte)0x00,
+                (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00,
+                (byte)0x73, (byte)0x87, (byte)0x07, (byte)0x00,
+                (byte)0x02, (byte)0xA0, (byte)0x0F, (byte)0x00,
+                (byte)0x16, (byte)0x00, (byte)0x00, (byte)0x00};
+        // copy first 22 bytes of TIFF header to byte array
+        for (int i = 0; i < 22; i++) {
+            ba[i] = header[i];
+        }
+        ByteArrayInputStream bais = new ByteArrayInputStream(ba);
+        ImageInputStream stream = ImageIO.createImageInputStream(bais);
+        Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
+
+        if(readers.hasNext()) {
+            ImageReader reader = readers.next();
+            reader.setInput(stream);
+            try {
+                reader.readAll(0, null);
+            } catch (IllegalArgumentException e) {
+                // do nothing we expect IllegalArgumentException but we
+                // should not throw IndexOutOfBoundsException.
+                System.out.println(e.toString());
+                System.out.println("Caught IllegalArgumentException ignore it");
+            }
+        } else {
+            throw new RuntimeException("No readers available for TIFF format");
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/JTextComponent/5074573/bug5074573.java
+++ b/test/jdk/javax/swing/text/JTextComponent/5074573/bug5074573.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,18 +24,27 @@
 /*
  * @test
  * @key headful
- * @bug 5074573
+ * @bug 5074573 8196100
  * @summary tests delte-next-word and delete-prev-word actions for all text compnents and all look&feels
- * @author Igor Kushnirskiy
  * @run main bug5074573
  */
 
-import java.util.*;
 import java.awt.Robot;
-import java.awt.Toolkit;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.text.*;
+import java.awt.event.KeyEvent;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.JEditorPane;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JPasswordField;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.text.Caret;
+import javax.swing.text.JTextComponent;
 
 public class bug5074573 {
 
@@ -148,6 +157,7 @@ public class bug5074573 {
             textComponent.setText(testString);
             frame.add(textComponent);
             frame.pack();
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
             textComponent.requestFocus();
             Caret caret = textComponent.getCaret();

--- a/test/jdk/jdk/jfr/jvm/TestPrimitiveClasses.java
+++ b/test/jdk/jdk/jfr/jvm/TestPrimitiveClasses.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jvm;
+
+import java.util.List;
+
+import jdk.jfr.Event;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test TestPrimitiveClasses
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.jvm.TestPrimitiveClasses
+ */
+public class TestPrimitiveClasses {
+
+    private static class MyEvent extends Event {
+        Class<?> booleanClass = boolean.class;
+        Class<?> charClass = char.class;
+        Class<?> floatClass = float.class;
+        Class<?> doubleClass = double.class;
+        Class<?> byteClass = byte.class;
+        Class<?> shortClass = short.class;
+        Class<?> intClass = int.class;
+        Class<?> longClass = long.class;
+        Class<?> voidClass = void.class;
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(MyEvent.class);
+            r.start();
+            MyEvent myEvent = new MyEvent();
+            myEvent.commit();
+            r.stop();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+            RecordedEvent event = events.get(0);
+            System.out.println(event);
+            testField(event, "booleanClass", boolean.class);
+            testField(event, "charClass", char.class);
+            testField(event, "floatClass", float.class);
+            testField(event, "doubleClass", double.class);
+            testField(event, "byteClass", byte.class);
+            testField(event, "shortClass", short.class);
+            testField(event, "intClass", int.class);
+            testField(event, "longClass", long.class);
+            testField(event, "voidClass", void.class);
+        }
+    }
+
+    private static void testField(RecordedEvent event, String fieldName, Class<?> expected) {
+        Asserts.assertTrue(event.hasField(fieldName));
+        RecordedClass classField = event.getValue(fieldName);
+        Asserts.assertEquals(classField.getName(), expected.getName());
+        Asserts.assertEquals(classField.getClassLoader().getName(), "bootstrap");
+        Asserts.assertEquals(classField.getModifiers(), expected.getModifiers());
+    }
+}

--- a/test/jdk/jdk/nio/zipfs/LargeCompressedEntrySizeTest.java
+++ b/test/jdk/jdk/nio/zipfs/LargeCompressedEntrySizeTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @test
+ * @bug 8190753 8011146
+ * @summary Verify that using zip filesystem for opening an outputstream for a zip entry whose
+ * compressed size is large, doesn't run into "Negative initial size" exception
+ * @run testng/manual/othervm LargeCompressedEntrySizeTest
+ */
+public class LargeCompressedEntrySizeTest {
+
+    private static final String LARGE_FILE_NAME = "LargeZipEntry.txt";
+    private static final String ZIP_FILE_NAME = "8190753-test-compressed-size.zip";
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        deleteFiles();
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        deleteFiles();
+    }
+
+    /**
+     * Delete the files created for use by the test
+     *
+     * @throws IOException if an error occurs deleting the files
+     */
+    private static void deleteFiles() throws IOException {
+        Files.deleteIfExists(Path.of(ZIP_FILE_NAME));
+    }
+
+
+    /**
+     * Using zip filesystem, creates a zip file and writes out a zip entry whose compressed size is
+     * expected to be greater than 2gb.
+     */
+    @Test
+    public void testLargeCompressedSizeWithZipFS() throws Exception {
+        final Path zipFile = Path.of(ZIP_FILE_NAME);
+        final long largeEntrySize = 6L * 1024L * 1024L * 1024L; // large value which exceeds Integer.MAX_VALUE
+        try (FileSystem fs = FileSystems.newFileSystem(zipFile, Collections.singletonMap("create", "true"))) {
+            try (OutputStream os = Files.newOutputStream(fs.getPath(LARGE_FILE_NAME))) {
+                long remaining = largeEntrySize;
+                // create a chunk of random bytes which we keep writing out
+                final int chunkSize = 102400;
+                final byte[] chunk = new byte[chunkSize];
+                new Random().nextBytes(chunk);
+                final long start = System.currentTimeMillis();
+                for (long l = 0; l < largeEntrySize; l += chunkSize) {
+                    final int numToWrite = (int) Math.min(remaining, chunkSize);
+                    os.write(chunk, 0, numToWrite);
+                    remaining -= numToWrite;
+                }
+                System.out.println("Took " + TimeUnit.SECONDS.toSeconds(System.currentTimeMillis() - start)
+                        + " seconds to generate entry of size " + largeEntrySize);
+            }
+        }
+    }
+
+}

--- a/test/jdk/jdk/nio/zipfs/ZipFSOutputStreamTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSOutputStreamTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Random;
+
+
+/**
+ * @test
+ * @summary Verify that the outputstream created for zip file entries, through the ZipFileSystem
+ * works fine for varying sizes of the zip file entries
+ * @bug 8190753 8011146
+ * @run testng/timeout=300 ZipFSOutputStreamTest
+ */
+public class ZipFSOutputStreamTest {
+    // List of files to be added to the ZIP file along with their sizes in bytes
+    private static final Map<String, Long> ZIP_ENTRIES = Map.of(
+            "f1", Integer.MAX_VALUE + 1L, // a value which when cast to an integer, becomes a negative value
+            "f2", 25L * 1024L * 1024L, // 25 MB
+            "d1/f3", 1234L,
+            "d1/d2/f4", 0L);
+
+    private static final Path ZIP_FILE = Path.of("zipfs-outputstream-test.zip");
+
+    @BeforeMethod
+    public void setUp() throws IOException {
+        deleteFiles();
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        deleteFiles();
+    }
+
+    private static void deleteFiles() throws IOException {
+        Files.deleteIfExists(ZIP_FILE);
+    }
+
+    @DataProvider(name = "zipFSCreationEnv")
+    private Object[][] zipFSCreationEnv() {
+        return new Object[][]{
+                {Map.of("create", "true", "noCompression", "true")}, // STORED
+                {Map.of("create", "true", "noCompression", "false")} // DEFLATED
+
+        };
+    }
+
+    /**
+     * Create a zip filesystem and write out entries of varying sizes using the outputstream returned
+     * by the ZipFileSystem. Then verify that the generated zip file entries are as expected,
+     * both in size and content
+     */
+    @Test(dataProvider = "zipFSCreationEnv")
+    public void testOutputStream(final Map<String, ?> env) throws Exception {
+        final byte[] chunk = new byte[1024];
+        new Random().nextBytes(chunk);
+        try (final FileSystem zipfs = FileSystems.newFileSystem(ZIP_FILE, env)) {
+            // create the zip with varying sized entries
+            for (final Map.Entry<String, Long> entry : ZIP_ENTRIES.entrySet()) {
+                final Path entryPath = zipfs.getPath(entry.getKey());
+                if (entryPath.getParent() != null) {
+                    Files.createDirectories(entryPath.getParent());
+                }
+                try (final OutputStream os = Files.newOutputStream(entryPath)) {
+                    writeAsChunks(os, chunk, entry.getValue());
+                }
+            }
+        }
+        // now verify the written content
+        try (final FileSystem zipfs = FileSystems.newFileSystem(ZIP_FILE)) {
+            for (final Map.Entry<String, Long> entry : ZIP_ENTRIES.entrySet()) {
+                final Path entryPath = zipfs.getPath(entry.getKey());
+                try (final InputStream is = Files.newInputStream(entryPath)) {
+                    final byte[] buf = new byte[chunk.length];
+                    int numRead;
+                    long totalRead = 0;
+                    while ((numRead = is.read(buf)) != -1) {
+                        totalRead += numRead;
+                        // verify the content
+                        for (int i = 0, chunkoffset = (int) ((totalRead - numRead) % chunk.length);
+                             i < numRead; i++, chunkoffset++) {
+                            Assert.assertEquals(buf[i], chunk[chunkoffset % chunk.length],
+                                    "Unexpected content in " + entryPath);
+                        }
+                    }
+                    Assert.assertEquals(totalRead, (long) entry.getValue(),
+                            "Unexpected number of bytes read from zip entry " + entryPath);
+                }
+            }
+        }
+    }
+
+    /**
+     * Repeatedly writes out to the outputstream, the chunk of data, till the number of bytes
+     * written to the stream equals the totalSize
+     */
+    private static void writeAsChunks(final OutputStream os, final byte[] chunk,
+                                      final long totalSize) throws IOException {
+        long remaining = totalSize;
+        for (long l = 0; l < totalSize; l += chunk.length) {
+            final int numToWrite = (int) Math.min(remaining, chunk.length);
+            os.write(chunk, 0, numToWrite);
+            remaining -= numToWrite;
+        }
+    }
+}

--- a/test/jdk/sun/net/www/http/RequestMethodCheck/RequestMethodEquality.java
+++ b/test/jdk/sun/net/www/http/RequestMethodCheck/RequestMethodEquality.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @summary This test checks that a broken HttpClient is not returned from the KeepAliveCache
+ *          when the intial HttpURLConnection.setRequest method is passed a 'new String("POST")'
+ *          rather than the "POST" String literal
+ * @bug 8274779
+ * @library /test/lib
+ * @modules java.base/sun.net.www.http
+ *          java.base/sun.net.www.protocol.http
+ * @build java.base/sun.net.www.http.HttpClientAccess
+ * @run testng/othervm RequestMethodEquality
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import sun.net.www.http.HttpClient;
+import sun.net.www.http.HttpClientAccess;
+import sun.net.www.http.KeepAliveCache;
+import sun.net.www.protocol.http.HttpURLConnection;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+
+public class RequestMethodEquality {
+    private static final String TEST_CONTEXT = "/reqmethodtest";
+    private HttpServer server;
+    private CustomHandler handler;
+    private HttpClientAccess httpClientAccess;
+
+    @BeforeTest
+    public void setup() throws Exception {
+        handler = new CustomHandler();
+        server = createServer(handler);
+        httpClientAccess = new HttpClientAccess();
+    }
+
+    @AfterTest
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testHttpClient() throws Exception {
+        HttpURLConnection conn = null;
+        try {
+            URL url = URIBuilder.newBuilder()
+                    .scheme("http")
+                    .host(server.getAddress().getAddress())
+                    .port(server.getAddress().getPort())
+                    .path(TEST_CONTEXT)
+                    .toURL();
+
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setChunkedStreamingMode(8); // ensures the call to HttpURLConnection.streaming() passes
+
+            int firstConnectTimeout = 1234;
+            HttpClient freshClient = HttpClient.New(url, Proxy.NO_PROXY, firstConnectTimeout, true, conn);
+            freshClient.closeServer(); // ensures that the call to HttpClient.available() fails
+
+            httpClientAccess.setInCache(freshClient, true); // allows the assertion in HttpClient.New to pass
+
+            // Injecting a mock KeepAliveCache that the HttpClient can use
+            KeepAliveCache kac = httpClientAccess.getKeepAliveCache();
+            kac.put(url, null, freshClient);
+
+            // The 'new' keyword is important here as the original code
+            // used '==' rather than String.equals to compare request methods
+            conn.setRequestMethod(new String("POST"));
+
+            // Before the fix, the value returned to 'cachedClient' would have been the (broken) cached
+            // 'freshClient' as HttpClient.available() could never be checked
+            int secondConnectTimeout = 4321;
+            HttpClient cachedClient = HttpClient.New(url, Proxy.NO_PROXY, secondConnectTimeout, true, conn);
+            cachedClient.closeServer();
+
+            int originalConnectTimeout = freshClient.getConnectTimeout();
+            int cachedConnectTimeout = cachedClient.getConnectTimeout();
+
+            // If both connectTimeout values are equal, it means the test retrieved the same broken
+            // HttpClient from the cache and is trying to re-use it.
+            Assert.assertNotEquals(originalConnectTimeout, cachedConnectTimeout, "Both connectTimeout values are equal.\nThis means the test is reusing a broken HttpClient rather than creating a new one.");
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    private static HttpServer createServer(final HttpHandler handler) throws IOException {
+        final InetSocketAddress serverAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        final int backlog = -1;
+        final HttpServer server = HttpServer.create(serverAddress, backlog);
+        server.createContext(TEST_CONTEXT, handler);
+        server.start();
+        System.out.println("Server started on " + server.getAddress());
+        return server;
+    }
+
+    private static class CustomHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            // We'll always send 200 OK - We don't care about the server logic
+            exchange.sendResponseHeaders(200, 1);
+            exchange.close();
+        }
+    }
+}

--- a/test/jdk/sun/net/www/http/RequestMethodCheck/java.base/sun/net/www/http/HttpClientAccess.java
+++ b/test/jdk/sun/net/www/http/RequestMethodCheck/java.base/sun/net/www/http/HttpClientAccess.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.net.www.http;
+// We can use this injected accessor class to get the KeepAliveCache from our HttpClient
+public class HttpClientAccess {
+    public KeepAliveCache getKeepAliveCache () {
+        // kac is a protected static field in HttpClient
+        return HttpClient.kac;
+    }
+
+    public void setInCache(HttpClient client, boolean inCache) {
+        client.inCache = inCache;
+    }
+}

--- a/test/jdk/sun/security/tools/jarsigner/warnings/LowerCaseManifest.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/LowerCaseManifest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.util.JarUtils;
+
+import java.nio.file.*;
+import java.security.Security;
+import java.util.Collections;
+
+
+/**
+ * @test
+ * @bug 8273826
+ * @summary Test for signed jar file with lowercase META-INF files
+ * @library /test/lib ../
+ * @build jdk.test.lib.util.JarUtils
+ * @run main LowerCaseManifest
+ */
+public class LowerCaseManifest extends Test {
+
+    public static void main(String[] args) throws Throwable {
+        new LowerCaseManifest().start();
+    }
+
+    private void start() throws Throwable {
+        // create a jar file that contains one class file
+        Utils.createFiles(FIRST_FILE);
+        JarUtils.createJar(UNSIGNED_JARFILE, FIRST_FILE);
+
+        // create key pair for jar signing
+        createAlias(CA_KEY_ALIAS, "-ext", "bc:c");
+        createAlias(KEY_ALIAS);
+
+        issueCert(KEY_ALIAS);
+
+        // sign jar
+        OutputAnalyzer analyzer = jarsigner(
+                "-keystore", KEYSTORE,
+                "-verbose",
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                "-signedjar", SIGNED_JARFILE,
+                UNSIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkSigning(analyzer);
+
+        // verify signed jar
+        analyzer = jarsigner(
+                "-verify",
+                "-verbose",
+                "-keystore", KEYSTORE,
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                SIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkVerifying(analyzer, 0, JAR_VERIFIED);
+
+        // verify signed jar in strict mode
+        analyzer = jarsigner(
+                "-verify",
+                "-verbose",
+                "-strict",
+                "-keystore", KEYSTORE,
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                SIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkVerifying(analyzer, 0, JAR_VERIFIED);
+
+        // convert the META-INF/ files to lower case
+        FileSystem fs = FileSystems.newFileSystem(Path.of(SIGNED_JARFILE), Collections.emptyMap());
+        for (String s : new String[]{"ALIAS.SF",  "ALIAS.RSA", "MANIFEST.MF"}) {
+            Path origPath = fs.getPath("META-INF/" + s);
+            Path lowerCase = fs.getPath("META-INF/" + s.toLowerCase());
+            Files.write(lowerCase, Files.readAllBytes(origPath));
+            Files.delete(origPath);
+        }
+        fs.close();
+
+        // verify signed jar in strict mode (with lower case META-INF names in place)
+        analyzer = jarsigner(
+                "-verify",
+                "-verbose",
+                "-strict",
+                "-J-Djava.security.debug=jar",
+                "-keystore", KEYSTORE,
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                SIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkVerifying(analyzer, 0,
+                JAR_VERIFIED, "!not present in verifiedSigners");
+        System.out.println("Test passed");
+    }
+
+}

--- a/test/jdk/sun/util/calendar/CalendarSystemDeadLockTest.java
+++ b/test/jdk/sun/util/calendar/CalendarSystemDeadLockTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * @test
+ * @bug 8273790
+ * @summary Verify that concurrent classloading of sun.util.calendar.Gregorian and
+ * sun.util.calendar.CalendarSystem doesn't lead to a deadlock
+ * @modules java.base/sun.util.calendar:open
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ */
+public class CalendarSystemDeadLockTest {
+
+    public static void main(final String[] args) throws Exception {
+        testConcurrentClassLoad();
+    }
+
+    /**
+     * Loads {@code sun.util.calendar.Gregorian} and {@code sun.util.calendar.CalendarSystem}
+     * and invokes {@code sun.util.calendar.CalendarSystem#getGregorianCalendar()} concurrently
+     * in a thread of their own and expects the classloading of both those classes
+     * to succeed. Additionally, after these tasks are done, calls the
+     * sun.util.calendar.CalendarSystem#getGregorianCalendar() and expects it to return a singleton
+     * instance
+     */
+    private static void testConcurrentClassLoad() throws Exception {
+        final int numTasks = 7;
+        final CountDownLatch taskTriggerLatch = new CountDownLatch(numTasks);
+        final List<Callable<?>> tasks = new ArrayList<>();
+        // add the sun.util.calendar.Gregorian and sun.util.calendar.CalendarSystem for classloading.
+        // there are main 2 classes which had a cyclic call in their static init
+        tasks.add(new ClassLoadTask("sun.util.calendar.Gregorian", taskTriggerLatch));
+        tasks.add(new ClassLoadTask("sun.util.calendar.CalendarSystem", taskTriggerLatch));
+        // add a few other classes for classloading, those which call CalendarSystem#getGregorianCalendar()
+        // or CalendarSystem#forName() during their static init
+        tasks.add(new ClassLoadTask("java.util.GregorianCalendar", taskTriggerLatch));
+        tasks.add(new ClassLoadTask("java.util.Date", taskTriggerLatch));
+        tasks.add(new ClassLoadTask("java.util.JapaneseImperialCalendar", taskTriggerLatch));
+        // add a couple of tasks which directly invoke sun.util.calendar.CalendarSystem#getGregorianCalendar()
+        tasks.add(new GetGregorianCalTask(taskTriggerLatch));
+        tasks.add(new GetGregorianCalTask(taskTriggerLatch));
+        // before triggering the tests make sure we have created the correct number of tasks
+        // the countdown latch uses/expects
+        if (numTasks != tasks.size()) {
+            throw new RuntimeException("Test setup failure - unexpected number of tasks " + tasks.size()
+                    + ", expected " + numTasks);
+        }
+        final ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+        try {
+            final Future<?>[] results = new Future[tasks.size()];
+            // submit
+            int i = 0;
+            for (final Callable<?> task : tasks) {
+                results[i++] = executor.submit(task);
+            }
+            // wait for completion
+            for (i = 0; i < tasks.size(); i++) {
+                results[i].get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+        // check that the sun.util.calendar.CalendarSystem#getGregorianCalendar() does indeed return
+        // a proper instance
+        final Object gCal = callCalSystemGetGregorianCal();
+        if (gCal == null) {
+            throw new RuntimeException("sun.util.calendar.CalendarSystem#getGregorianCalendar()" +
+                    " unexpectedly returned null");
+        }
+        // now verify that each call to getGregorianCalendar(), either in the tasks or here, returned the exact
+        // same instance
+        if (GetGregorianCalTask.instances.size() != 2) {
+            throw new RuntimeException("Unexpected number of results from call " +
+                    "to sun.util.calendar.CalendarSystem#getGregorianCalendar()");
+        }
+        // intentional identity check since sun.util.calendar.CalendarSystem#getGregorianCalendar() is
+        // expected to return a singleton instance
+        if ((gCal != GetGregorianCalTask.instances.get(0)) || (gCal != GetGregorianCalTask.instances.get(1))) {
+            throw new RuntimeException("sun.util.calendar.CalendarSystem#getGregorianCalendar()" +
+                    " returned different instances");
+        }
+    }
+
+    /**
+     * Reflectively calls sun.util.calendar.CalendarSystem#getGregorianCalendar() and returns
+     * the result
+     */
+    private static Object callCalSystemGetGregorianCal() throws Exception {
+        final Class<?> k = Class.forName("sun.util.calendar.CalendarSystem");
+        return k.getDeclaredMethod("getGregorianCalendar").invoke(null);
+    }
+
+    private static class ClassLoadTask implements Callable<Class<?>> {
+        private final String className;
+        private final CountDownLatch latch;
+
+        private ClassLoadTask(final String className, final CountDownLatch latch) {
+            this.className = className;
+            this.latch = latch;
+        }
+
+        @Override
+        public Class<?> call() {
+            System.out.println(Thread.currentThread().getName() + " loading " + this.className);
+            try {
+                // let the other tasks know we are ready to trigger our work
+                latch.countDown();
+                // wait for the other task to let us know they are ready to trigger their work too
+                latch.await();
+                return Class.forName(this.className);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static class GetGregorianCalTask implements Callable<Object> {
+        // keeps track of the instances returned by calls to sun.util.calendar.CalendarSystem#getGregorianCalendar()
+        // by this task
+        private static final List<Object> instances = Collections.synchronizedList(new ArrayList<>());
+        private final CountDownLatch latch;
+
+        private GetGregorianCalTask(final CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public Object call() {
+            System.out.println(Thread.currentThread().getName()
+                    + " calling  sun.util.calendar.CalendarSystem#getGregorianCalendar()");
+            try {
+                // let the other tasks know we are ready to trigger our work
+                latch.countDown();
+                // wait for the other task to let us know they are ready to trigger their work too
+                latch.await();
+                final Object inst = callCalSystemGetGregorianCal();
+                instances.add(inst);
+                return inst;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Переношу этот рефакторинг кода: https://github.com/openjdk/jdk/pull/154, ему как раз соответствует [JDK 8253015](https://bugs.openjdk.java.net/browse/JDK-8253015). Вместе с ним еще 3 коммита, исправляющих в нем ошибки:
* исправление `static_assert`-ов: https://github.com/openjdk/jdk/pull/1088
* аккуратное удаление проверки `guarantee(cpu_lines == os::processor_count(), "core count should be consistent");` и связанных с нею идейно штук:
  * просто ее удаление: https://github.com/openjdk/jdk/pull/983
  * удаление строк, связанных с не всегда работающим определением флага CPU_A53MAC через число cpu: https://github.com/openjdk/jdk/pull/1084