### PR TITLE
JDK 8253015 v2

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5250,7 +5250,7 @@ void MacroAssembler::cache_wb(Address line) {
   assert(line.offset() == 0, "offset should be 0");
   // would like to assert this
   // assert(line._ext.shift == 0, "shift should be zero");
-  if (VM_Version::supports_dcpop()) {
+  if (VM_Version::features() & VM_Version::CPU_DCPOP) {
     // writeback using clear virtual address to point of persistence
     dc(Assembler::CVAP, line.base());
   } else {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -173,10 +173,6 @@ void VM_Version::initialize() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
-  // we assume the worst and assume we could be on a big little system and have
-  // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
   char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -24,17 +24,22 @@
  */
 
 #include "precompiled.hpp"
+<<<<<<< HEAD
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "memory/resourceArea.hpp"
+=======
+#include "runtime/arguments.hpp"
+#include "runtime/globals_extension.hpp"
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
-#include "runtime/stubCodeGenerator.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/macros.hpp"
 
 #include OS_HEADER_INLINE(os)
 
+<<<<<<< HEAD
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
 
@@ -62,12 +67,15 @@
 #define HWCAP_ATOMICS (1<<8)
 #endif
 
+=======
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 int VM_Version::_cpu;
 int VM_Version::_model;
 int VM_Version::_model2;
 int VM_Version::_variant;
 int VM_Version::_revision;
 int VM_Version::_stepping;
+<<<<<<< HEAD
 bool VM_Version::_dcpop;
 VM_Version::PsrInfo VM_Version::_psr_info   = { 0, };
 
@@ -82,44 +90,27 @@ static getPsrInfo_stub_t getPsrInfo_stub = NULL;
 
 class VM_Version_StubGenerator: public StubCodeGenerator {
  public:
+=======
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
-  VM_Version_StubGenerator(CodeBuffer *c) : StubCodeGenerator(c) {}
+int VM_Version::_zva_length;
+int VM_Version::_dcache_line_size;
+int VM_Version::_icache_line_size;
+int VM_Version::_initial_sve_vector_length;
 
-  address generate_getPsrInfo() {
-    StubCodeMark mark(this, "VM_Version", "getPsrInfo_stub");
-#   define __ _masm->
-    address start = __ pc();
-
-    // void getPsrInfo(VM_Version::PsrInfo* psr_info);
-
-    address entry = __ pc();
-
-    __ enter();
-
-    __ get_dczid_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::dczid_el0_offset())));
-
-    __ get_ctr_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::ctr_el0_offset())));
-
-    __ leave();
-    __ ret(lr);
-
-#   undef __
-
-    return start;
-  }
-};
-
+<<<<<<< HEAD
 
 void VM_Version::get_processor_features() {
+=======
+void VM_Version::initialize() {
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   _supports_cx8 = true;
   _supports_atomic_getset4 = true;
   _supports_atomic_getadd4 = true;
   _supports_atomic_getset8 = true;
   _supports_atomic_getadd8 = true;
 
-  getPsrInfo_stub(&_psr_info);
+  get_os_cpu_info();
 
   int dcache_line = VM_Version::dcache_line_size();
 
@@ -161,6 +152,7 @@ void VM_Version::get_processor_features() {
     SoftwarePrefetchHintDistance &= ~7;
   }
 
+<<<<<<< HEAD
   uint64_t auxv = getauxval(AT_HWCAP);
 
   char buf[512];
@@ -193,12 +185,14 @@ void VM_Version::get_processor_features() {
     }
     fclose(f);
   }
+=======
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
   if (os::supports_map_sync()) {
     // if dcpop is available publish data cache line flush size via
     // generic field, otherwise let if default to zero thereby
     // disabling writeback
-    if (_dcpop) {
+    if (_features & CPU_DCPOP) {
       _data_cache_line_flush_size = dcache_line;
     }
   }
@@ -273,27 +267,40 @@ void VM_Version::get_processor_features() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cpu_lines == 1) then if _model is an A57 (0xd07)
+  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
   // we assume the worst and assume we could be on a big little system and have
   // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && cpu_lines == 1 && _model == 0xd07) _features |= CPU_A53MAC;
+  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
+  char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
   if (_model2) sprintf(buf+strlen(buf), "(0x%03x)", _model2);
+<<<<<<< HEAD
   if (auxv & HWCAP_ASIMD) strcat(buf, ", simd");
   if (auxv & HWCAP_CRC32) strcat(buf, ", crc");
   if (auxv & HWCAP_AES)   strcat(buf, ", aes");
   if (auxv & HWCAP_SHA1)  strcat(buf, ", sha1");
   if (auxv & HWCAP_SHA2)  strcat(buf, ", sha256");
   if (auxv & HWCAP_ATOMICS) strcat(buf, ", lse");
+=======
+  if (_features & CPU_ASIMD) strcat(buf, ", simd");
+  if (_features & CPU_CRC32) strcat(buf, ", crc");
+  if (_features & CPU_AES)   strcat(buf, ", aes");
+  if (_features & CPU_SHA1)  strcat(buf, ", sha1");
+  if (_features & CPU_SHA2)  strcat(buf, ", sha256");
+  if (_features & CPU_SHA512) strcat(buf, ", sha512");
+  if (_features & CPU_LSE) strcat(buf, ", lse");
+  if (_features & CPU_SVE) strcat(buf, ", sve");
+  if (_features & CPU_SVE2) strcat(buf, ", sve2");
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
   _features_string = os::strdup(buf);
 
   if (FLAG_IS_DEFAULT(UseCRC32)) {
-    UseCRC32 = (auxv & HWCAP_CRC32) != 0;
+    UseCRC32 = (_features & CPU_CRC32) != 0;
   }
 
-  if (UseCRC32 && (auxv & HWCAP_CRC32) == 0) {
+  if (UseCRC32 && (_features & CPU_CRC32) == 0) {
     warning("UseCRC32 specified, but not supported on this CPU");
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
@@ -307,7 +314,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }
 
-  if (auxv & HWCAP_ATOMICS) {
+  if (_features & CPU_LSE) {
     if (FLAG_IS_DEFAULT(UseLSE))
       FLAG_SET_DEFAULT(UseLSE, true);
   } else {
@@ -317,7 +324,7 @@ void VM_Version::get_processor_features() {
     }
   }
 
-  if (auxv & HWCAP_AES) {
+  if (_features & CPU_AES) {
     UseAES = UseAES || FLAG_IS_DEFAULT(UseAES);
     UseAESIntrinsics =
         UseAESIntrinsics || (UseAES && FLAG_IS_DEFAULT(UseAESIntrinsics));
@@ -345,7 +352,7 @@ void VM_Version::get_processor_features() {
     UseCRC32Intrinsics = true;
   }
 
-  if (auxv & HWCAP_CRC32) {
+  if (_features & CPU_CRC32) {
     if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
       FLAG_SET_DEFAULT(UseCRC32CIntrinsics, true);
     }
@@ -358,7 +365,16 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
+<<<<<<< HEAD
   if (auxv & (HWCAP_SHA1 | HWCAP_SHA2)) {
+=======
+  if (UseMD5Intrinsics) {
+    warning("MD5 intrinsics are not available on this CPU");
+    FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
+  }
+
+  if (_features & (CPU_SHA1 | CPU_SHA2)) {
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
     if (FLAG_IS_DEFAULT(UseSHA)) {
       FLAG_SET_DEFAULT(UseSHA, true);
     }
@@ -367,7 +383,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA1)) {
+  if (UseSHA && (_features & CPU_SHA1)) {
     if (FLAG_IS_DEFAULT(UseSHA1Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA1Intrinsics, true);
     }
@@ -376,7 +392,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA1Intrinsics, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA2)) {
+  if (UseSHA && (_features & CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA256Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA256Intrinsics, true);
     }
@@ -385,7 +401,16 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA256Intrinsics, false);
   }
 
+<<<<<<< HEAD
   if (UseSHA512Intrinsics) {
+=======
+  if (UseSHA && (_features & CPU_SHA512)) {
+    // Do not auto-enable UseSHA512Intrinsics until it has been fully tested on hardware
+    // if (FLAG_IS_DEFAULT(UseSHA512Intrinsics)) {
+      // FLAG_SET_DEFAULT(UseSHA512Intrinsics, true);
+    // }
+  } else if (UseSHA512Intrinsics) {
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
     warning("Intrinsics for SHA-384 and SHA-512 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseSHA512Intrinsics, false);
   }
@@ -394,7 +419,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (auxv & HWCAP_PMULL) {
+  if (_features & CPU_PMULL) {
     if (FLAG_IS_DEFAULT(UseGHASHIntrinsics)) {
       FLAG_SET_DEFAULT(UseGHASHIntrinsics, true);
     }
@@ -415,6 +440,21 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseBlockZeroing, false);
   }
 
+<<<<<<< HEAD
+=======
+  if (_features & CPU_SVE) {
+    if (FLAG_IS_DEFAULT(UseSVE)) {
+      FLAG_SET_DEFAULT(UseSVE, (_features & CPU_SVE2) ? 2 : 1);
+    }
+    if (UseSVE > 0) {
+      _initial_sve_vector_length = get_current_sve_vector_length();
+    }
+  } else if (UseSVE > 0) {
+    warning("UseSVE specified, but not supported on current CPU. Disabling SVE.");
+    FLAG_SET_DEFAULT(UseSVE, 0);
+  }
+
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   // This machine allows unaligned memory accesses
   if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
     FLAG_SET_DEFAULT(UseUnalignedAccesses, true);
@@ -449,6 +489,51 @@ void VM_Version::get_processor_features() {
     UseMontgomerySquareIntrinsic = true;
   }
 
+<<<<<<< HEAD
+=======
+  if (UseSVE > 0) {
+    if (FLAG_IS_DEFAULT(MaxVectorSize)) {
+      MaxVectorSize = _initial_sve_vector_length;
+    } else if (MaxVectorSize < 16) {
+      warning("SVE does not support vector length less than 16 bytes. Disabling SVE.");
+      UseSVE = 0;
+    } else if ((MaxVectorSize % 16) == 0 && is_power_of_2(MaxVectorSize)) {
+      int new_vl = set_and_get_current_sve_vector_lenght(MaxVectorSize);
+      _initial_sve_vector_length = new_vl;
+      // Update MaxVectorSize to the largest supported value.
+      if (new_vl < 0) {
+        vm_exit_during_initialization(
+          err_msg("Current system does not support SVE vector length for MaxVectorSize: %d",
+                  (int)MaxVectorSize));
+      } else if (new_vl != MaxVectorSize) {
+        warning("Current system only supports max SVE vector length %d. Set MaxVectorSize to %d",
+                new_vl, new_vl);
+      }
+      MaxVectorSize = new_vl;
+    } else {
+      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
+    }
+  }
+
+  if (UseSVE == 0) {  // NEON
+    int min_vector_size = 8;
+    int max_vector_size = 16;
+    if (!FLAG_IS_DEFAULT(MaxVectorSize)) {
+      if (!is_power_of_2(MaxVectorSize)) {
+        vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
+      } else if (MaxVectorSize < min_vector_size) {
+        warning("MaxVectorSize must be at least %i on this platform", min_vector_size);
+        FLAG_SET_DEFAULT(MaxVectorSize, min_vector_size);
+      } else if (MaxVectorSize > max_vector_size) {
+        warning("MaxVectorSize must be at most %i on this platform", max_vector_size);
+        FLAG_SET_DEFAULT(MaxVectorSize, max_vector_size);
+      }
+    } else {
+      FLAG_SET_DEFAULT(MaxVectorSize, 16);
+    }
+  }
+
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   if (FLAG_IS_DEFAULT(OptoScheduling)) {
     OptoScheduling = true;
   }
@@ -457,22 +542,6 @@ void VM_Version::get_processor_features() {
     AlignVector = AvoidUnalignedAccesses;
   }
 #endif
-}
-
-void VM_Version::initialize() {
-  ResourceMark rm;
-
-  stub_blob = BufferBlob::create("getPsrInfo_stub", stub_size);
-  if (stub_blob == NULL) {
-    vm_exit_during_initialization("Unable to allocate getPsrInfo_stub");
-  }
-
-  CodeBuffer c(stub_blob);
-  VM_Version_StubGenerator g(&c);
-  getPsrInfo_stub = CAST_TO_FN_PTR(getPsrInfo_stub_t,
-                                   g.generate_getPsrInfo());
-
-  get_processor_features();
 
   UNSUPPORTED_OPTION(CriticalJNINatives);
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -24,14 +24,8 @@
  */
 
 #include "precompiled.hpp"
-<<<<<<< HEAD
-#include "asm/macroAssembler.hpp"
-#include "asm/macroAssembler.inline.hpp"
-#include "memory/resourceArea.hpp"
-=======
 #include "runtime/arguments.hpp"
 #include "runtime/globals_extension.hpp"
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
@@ -39,71 +33,19 @@
 
 #include OS_HEADER_INLINE(os)
 
-<<<<<<< HEAD
-#include <sys/auxv.h>
-#include <asm/hwcap.h>
-
-#ifndef HWCAP_AES
-#define HWCAP_AES   (1<<3)
-#endif
-
-#ifndef HWCAP_PMULL
-#define HWCAP_PMULL (1<<4)
-#endif
-
-#ifndef HWCAP_SHA1
-#define HWCAP_SHA1  (1<<5)
-#endif
-
-#ifndef HWCAP_SHA2
-#define HWCAP_SHA2  (1<<6)
-#endif
-
-#ifndef HWCAP_CRC32
-#define HWCAP_CRC32 (1<<7)
-#endif
-
-#ifndef HWCAP_ATOMICS
-#define HWCAP_ATOMICS (1<<8)
-#endif
-
-=======
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 int VM_Version::_cpu;
 int VM_Version::_model;
 int VM_Version::_model2;
 int VM_Version::_variant;
 int VM_Version::_revision;
 int VM_Version::_stepping;
-<<<<<<< HEAD
-bool VM_Version::_dcpop;
-VM_Version::PsrInfo VM_Version::_psr_info   = { 0, };
-
-static BufferBlob* stub_blob;
-static const int stub_size = 550;
-
-extern "C" {
-  typedef void (*getPsrInfo_stub_t)(void*);
-}
-static getPsrInfo_stub_t getPsrInfo_stub = NULL;
-
-
-class VM_Version_StubGenerator: public StubCodeGenerator {
- public:
-=======
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
 int VM_Version::_zva_length;
 int VM_Version::_dcache_line_size;
 int VM_Version::_icache_line_size;
 int VM_Version::_initial_sve_vector_length;
 
-<<<<<<< HEAD
-
-void VM_Version::get_processor_features() {
-=======
 void VM_Version::initialize() {
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   _supports_cx8 = true;
   _supports_atomic_getset4 = true;
   _supports_atomic_getadd4 = true;
@@ -151,42 +93,6 @@ void VM_Version::initialize() {
     warning("SoftwarePrefetchHintDistance must be -1, or a multiple of 8");
     SoftwarePrefetchHintDistance &= ~7;
   }
-
-<<<<<<< HEAD
-  uint64_t auxv = getauxval(AT_HWCAP);
-
-  char buf[512];
-
-  _features = auxv;
-
-  int cpu_lines = 0;
-  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
-    // need a large buffer as the flags line may include lots of text
-    char buf[1024], *p;
-    while (fgets(buf, sizeof (buf), f) != NULL) {
-      if ((p = strchr(buf, ':')) != NULL) {
-        long v = strtol(p+1, NULL, 0);
-        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
-          _cpu = v;
-          cpu_lines++;
-        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
-          _variant = v;
-        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
-          if (_model != v)  _model2 = _model;
-          _model = v;
-        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
-          _revision = v;
-        } else if (strncmp(buf, "flags", sizeof("flags") - 1) == 0) {
-          if (strstr(p+1, "dcpop")) {
-            _dcpop = true;
-          }
-        }
-      }
-    }
-    fclose(f);
-  }
-=======
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
   if (os::supports_map_sync()) {
     // if dcpop is available publish data cache line flush size via
@@ -275,24 +181,12 @@ void VM_Version::initialize() {
   char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
   if (_model2) sprintf(buf+strlen(buf), "(0x%03x)", _model2);
-<<<<<<< HEAD
-  if (auxv & HWCAP_ASIMD) strcat(buf, ", simd");
-  if (auxv & HWCAP_CRC32) strcat(buf, ", crc");
-  if (auxv & HWCAP_AES)   strcat(buf, ", aes");
-  if (auxv & HWCAP_SHA1)  strcat(buf, ", sha1");
-  if (auxv & HWCAP_SHA2)  strcat(buf, ", sha256");
-  if (auxv & HWCAP_ATOMICS) strcat(buf, ", lse");
-=======
   if (_features & CPU_ASIMD) strcat(buf, ", simd");
   if (_features & CPU_CRC32) strcat(buf, ", crc");
   if (_features & CPU_AES)   strcat(buf, ", aes");
   if (_features & CPU_SHA1)  strcat(buf, ", sha1");
   if (_features & CPU_SHA2)  strcat(buf, ", sha256");
-  if (_features & CPU_SHA512) strcat(buf, ", sha512");
   if (_features & CPU_LSE) strcat(buf, ", lse");
-  if (_features & CPU_SVE) strcat(buf, ", sve");
-  if (_features & CPU_SVE2) strcat(buf, ", sve2");
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
   _features_string = os::strdup(buf);
 
@@ -365,16 +259,7 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
-<<<<<<< HEAD
-  if (auxv & (HWCAP_SHA1 | HWCAP_SHA2)) {
-=======
-  if (UseMD5Intrinsics) {
-    warning("MD5 intrinsics are not available on this CPU");
-    FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
-  }
-
   if (_features & (CPU_SHA1 | CPU_SHA2)) {
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
     if (FLAG_IS_DEFAULT(UseSHA)) {
       FLAG_SET_DEFAULT(UseSHA, true);
     }
@@ -401,16 +286,7 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseSHA256Intrinsics, false);
   }
 
-<<<<<<< HEAD
   if (UseSHA512Intrinsics) {
-=======
-  if (UseSHA && (_features & CPU_SHA512)) {
-    // Do not auto-enable UseSHA512Intrinsics until it has been fully tested on hardware
-    // if (FLAG_IS_DEFAULT(UseSHA512Intrinsics)) {
-      // FLAG_SET_DEFAULT(UseSHA512Intrinsics, true);
-    // }
-  } else if (UseSHA512Intrinsics) {
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
     warning("Intrinsics for SHA-384 and SHA-512 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseSHA512Intrinsics, false);
   }
@@ -440,21 +316,6 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseBlockZeroing, false);
   }
 
-<<<<<<< HEAD
-=======
-  if (_features & CPU_SVE) {
-    if (FLAG_IS_DEFAULT(UseSVE)) {
-      FLAG_SET_DEFAULT(UseSVE, (_features & CPU_SVE2) ? 2 : 1);
-    }
-    if (UseSVE > 0) {
-      _initial_sve_vector_length = get_current_sve_vector_length();
-    }
-  } else if (UseSVE > 0) {
-    warning("UseSVE specified, but not supported on current CPU. Disabling SVE.");
-    FLAG_SET_DEFAULT(UseSVE, 0);
-  }
-
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   // This machine allows unaligned memory accesses
   if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
     FLAG_SET_DEFAULT(UseUnalignedAccesses, true);
@@ -489,51 +350,6 @@ void VM_Version::initialize() {
     UseMontgomerySquareIntrinsic = true;
   }
 
-<<<<<<< HEAD
-=======
-  if (UseSVE > 0) {
-    if (FLAG_IS_DEFAULT(MaxVectorSize)) {
-      MaxVectorSize = _initial_sve_vector_length;
-    } else if (MaxVectorSize < 16) {
-      warning("SVE does not support vector length less than 16 bytes. Disabling SVE.");
-      UseSVE = 0;
-    } else if ((MaxVectorSize % 16) == 0 && is_power_of_2(MaxVectorSize)) {
-      int new_vl = set_and_get_current_sve_vector_lenght(MaxVectorSize);
-      _initial_sve_vector_length = new_vl;
-      // Update MaxVectorSize to the largest supported value.
-      if (new_vl < 0) {
-        vm_exit_during_initialization(
-          err_msg("Current system does not support SVE vector length for MaxVectorSize: %d",
-                  (int)MaxVectorSize));
-      } else if (new_vl != MaxVectorSize) {
-        warning("Current system only supports max SVE vector length %d. Set MaxVectorSize to %d",
-                new_vl, new_vl);
-      }
-      MaxVectorSize = new_vl;
-    } else {
-      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
-    }
-  }
-
-  if (UseSVE == 0) {  // NEON
-    int min_vector_size = 8;
-    int max_vector_size = 16;
-    if (!FLAG_IS_DEFAULT(MaxVectorSize)) {
-      if (!is_power_of_2(MaxVectorSize)) {
-        vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
-      } else if (MaxVectorSize < min_vector_size) {
-        warning("MaxVectorSize must be at least %i on this platform", min_vector_size);
-        FLAG_SET_DEFAULT(MaxVectorSize, min_vector_size);
-      } else if (MaxVectorSize > max_vector_size) {
-        warning("MaxVectorSize must be at most %i on this platform", max_vector_size);
-        FLAG_SET_DEFAULT(MaxVectorSize, max_vector_size);
-      }
-    } else {
-      FLAG_SET_DEFAULT(MaxVectorSize, 16);
-    }
-  }
-
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   if (FLAG_IS_DEFAULT(OptoScheduling)) {
     OptoScheduling = true;
   }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -40,30 +40,13 @@ protected:
   static int _variant;
   static int _revision;
   static int _stepping;
-<<<<<<< HEAD
-  static bool _dcpop;
-  struct PsrInfo {
-    uint32_t dczid_el0;
-    uint32_t ctr_el0;
-  };
-  static PsrInfo _psr_info;
-  static void get_processor_features();
-=======
 
   static int _zva_length;
   static int _dcache_line_size;
   static int _icache_line_size;
-  static int _initial_sve_vector_length;
 
   // Read additional info using OS-specific interfaces
   static void get_os_cpu_info();
-
-  // Sets the SVE length and returns a new actual value or negative on error.
-  // If the len is larger than the system largest supported SVE vector length,
-  // the function sets the largest supported value.
-  static int set_and_get_current_sve_vector_lenght(int len);
-  static int get_current_sve_vector_length();
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
 public:
   // Initialization
@@ -114,10 +97,7 @@ public:
     CPU_CRC32        = (1<<7),
     CPU_LSE          = (1<<8),
     CPU_DCPOP        = (1<<16),
-    CPU_SHA512       = (1<<21),
-    CPU_SVE          = (1<<22),
     // flags above must follow Linux HWCAP
-    CPU_SVE2         = (1<<28),
     CPU_STXR_PREFETCH= (1<<29),
     CPU_A53MAC       = (1<<30),
   };
@@ -127,20 +107,8 @@ public:
   static int cpu_model2()                     { return _model2; }
   static int cpu_variant()                    { return _variant; }
   static int cpu_revision()                   { return _revision; }
-<<<<<<< HEAD
-  static bool supports_dcpop()                { return _dcpop; }
-  static ByteSize dczid_el0_offset() { return byte_offset_of(PsrInfo, dczid_el0); }
-  static ByteSize ctr_el0_offset()   { return byte_offset_of(PsrInfo, ctr_el0); }
-  static bool is_zva_enabled() {
-    // Check the DZP bit (bit 4) of dczid_el0 is zero
-    // and block size (bit 0~3) is not zero.
-    return ((_psr_info.dczid_el0 & 0x10) == 0 &&
-            (_psr_info.dczid_el0 & 0xf) != 0);
-  }
-=======
 
   static bool is_zva_enabled() { return 0 <= _zva_length; }
->>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   static int zva_length() {
     assert(is_zva_enabled(), "ZVA not available");
     return _zva_length;
@@ -148,7 +116,6 @@ public:
 
   static int icache_line_size() { return _icache_line_size; }
   static int dcache_line_size() { return _dcache_line_size; }
-  static int get_initial_sve_vector_length()  { return _initial_sve_vector_length; };
 
   static bool supports_fast_class_init_checks() { return true; }
 };

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -40,6 +40,7 @@ protected:
   static int _variant;
   static int _revision;
   static int _stepping;
+<<<<<<< HEAD
   static bool _dcpop;
   struct PsrInfo {
     uint32_t dczid_el0;
@@ -47,6 +48,22 @@ protected:
   };
   static PsrInfo _psr_info;
   static void get_processor_features();
+=======
+
+  static int _zva_length;
+  static int _dcache_line_size;
+  static int _icache_line_size;
+  static int _initial_sve_vector_length;
+
+  // Read additional info using OS-specific interfaces
+  static void get_os_cpu_info();
+
+  // Sets the SVE length and returns a new actual value or negative on error.
+  // If the len is larger than the system largest supported SVE vector length,
+  // the function sets the largest supported value.
+  static int set_and_get_current_sve_vector_lenght(int len);
+  static int get_current_sve_vector_length();
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
 
 public:
   // Initialization
@@ -96,8 +113,13 @@ public:
     CPU_SHA2         = (1<<6),
     CPU_CRC32        = (1<<7),
     CPU_LSE          = (1<<8),
-    CPU_STXR_PREFETCH= (1 << 29),
-    CPU_A53MAC       = (1 << 30),
+    CPU_DCPOP        = (1<<16),
+    CPU_SHA512       = (1<<21),
+    CPU_SVE          = (1<<22),
+    // flags above must follow Linux HWCAP
+    CPU_SVE2         = (1<<28),
+    CPU_STXR_PREFETCH= (1<<29),
+    CPU_A53MAC       = (1<<30),
   };
 
   static int cpu_family()                     { return _cpu; }
@@ -105,6 +127,7 @@ public:
   static int cpu_model2()                     { return _model2; }
   static int cpu_variant()                    { return _variant; }
   static int cpu_revision()                   { return _revision; }
+<<<<<<< HEAD
   static bool supports_dcpop()                { return _dcpop; }
   static ByteSize dczid_el0_offset() { return byte_offset_of(PsrInfo, dczid_el0); }
   static ByteSize ctr_el0_offset()   { return byte_offset_of(PsrInfo, ctr_el0); }
@@ -114,16 +137,19 @@ public:
     return ((_psr_info.dczid_el0 & 0x10) == 0 &&
             (_psr_info.dczid_el0 & 0xf) != 0);
   }
+=======
+
+  static bool is_zva_enabled() { return 0 <= _zva_length; }
+>>>>>>> ec9bee68660... 8253015: Aarch64: Move linux code out from generic CPU feature detection
   static int zva_length() {
     assert(is_zva_enabled(), "ZVA not available");
-    return 4 << (_psr_info.dczid_el0 & 0xf);
+    return _zva_length;
   }
-  static int icache_line_size() {
-    return (1 << (_psr_info.ctr_el0 & 0x0f)) * 4;
-  }
-  static int dcache_line_size() {
-    return (1 << ((_psr_info.ctr_el0 >> 16) & 0x0f)) * 4;
-  }
+
+  static int icache_line_size() { return _icache_line_size; }
+  static int dcache_line_size() { return _dcache_line_size; }
+  static int get_initial_sve_vector_length()  { return _initial_sve_vector_length; };
+
   static bool supports_fast_class_init_checks() { return true; }
 };
 

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -27,3 +27,140 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+
+#ifndef HWCAP_AES
+#define HWCAP_AES   (1<<3)
+#endif
+
+#ifndef HWCAP_PMULL
+#define HWCAP_PMULL (1<<4)
+#endif
+
+#ifndef HWCAP_SHA1
+#define HWCAP_SHA1  (1<<5)
+#endif
+
+#ifndef HWCAP_SHA2
+#define HWCAP_SHA2  (1<<6)
+#endif
+
+#ifndef HWCAP_CRC32
+#define HWCAP_CRC32 (1<<7)
+#endif
+
+#ifndef HWCAP_ATOMICS
+#define HWCAP_ATOMICS (1<<8)
+#endif
+
+#ifndef HWCAP_DCPOP
+#define HWCAP_DCPOP (1<<16)
+#endif
+
+#ifndef HWCAP_SHA512
+#define HWCAP_SHA512 (1 << 21)
+#endif
+
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1 << 22)
+#endif
+
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1 << 1)
+#endif
+
+#ifndef PR_SVE_GET_VL
+// For old toolchains which do not have SVE related macros defined.
+#define PR_SVE_SET_VL   50
+#define PR_SVE_GET_VL   51
+#endif
+
+int VM_Version::get_current_sve_vector_length() {
+  assert(_features & CPU_SVE, "should not call this");
+  return prctl(PR_SVE_GET_VL);
+}
+
+int VM_Version::set_and_get_current_sve_vector_lenght(int length) {
+  assert(_features & CPU_SVE, "should not call this");
+  int new_length = prctl(PR_SVE_SET_VL, length);
+  return new_length;
+}
+
+void VM_Version::get_os_cpu_info() {
+
+  uint64_t auxv = getauxval(AT_HWCAP);
+  uint64_t auxv2 = getauxval(AT_HWCAP2);
+
+  static_assert(CPU_FP      == HWCAP_FP);
+  static_assert(CPU_ASIMD   == HWCAP_ASIMD);
+  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM);
+  static_assert(CPU_AES     == HWCAP_AES);
+  static_assert(CPU_PMULL   == HWCAP_PMULL);
+  static_assert(CPU_SHA1    == HWCAP_SHA1);
+  static_assert(CPU_SHA2    == HWCAP_SHA2);
+  static_assert(CPU_CRC32   == HWCAP_CRC32);
+  static_assert(CPU_LSE     == HWCAP_ATOMICS);
+  static_assert(CPU_DCPOP   == HWCAP_DCPOP);
+  static_assert(CPU_SHA512  == HWCAP_SHA512);
+  static_assert(CPU_SVE     == HWCAP_SVE);
+  _features = auxv & (
+      HWCAP_FP      |
+      HWCAP_ASIMD   |
+      HWCAP_EVTSTRM |
+      HWCAP_AES     |
+      HWCAP_PMULL   |
+      HWCAP_SHA1    |
+      HWCAP_SHA2    |
+      HWCAP_CRC32   |
+      HWCAP_ATOMICS |
+      HWCAP_DCPOP   |
+      HWCAP_SHA512  |
+      HWCAP_SVE);
+
+  if (auxv2 & HWCAP2_SVE2) _features |= CPU_SVE2;
+
+  uint64_t ctr_el0;
+  uint64_t dczid_el0;
+  __asm__ (
+    "mrs %0, CTR_EL0\n"
+    "mrs %1, DCZID_EL0\n"
+    : "=r"(ctr_el0), "=r"(dczid_el0)
+  );
+
+  _icache_line_size = (1 << (ctr_el0 & 0x0f)) * 4;
+  _dcache_line_size = (1 << ((ctr_el0 >> 16) & 0x0f)) * 4;
+
+  if (!(dczid_el0 & 0x10)) {
+    _zva_length = 4 << (dczid_el0 & 0xf);
+  }
+
+  int cpu_lines = 0;
+  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
+    // need a large buffer as the flags line may include lots of text
+    char buf[1024], *p;
+    while (fgets(buf, sizeof (buf), f) != NULL) {
+      if ((p = strchr(buf, ':')) != NULL) {
+        long v = strtol(p+1, NULL, 0);
+        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
+          _cpu = v;
+          cpu_lines++;
+        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
+          _variant = v;
+        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
+          if (_model != v)  _model2 = _model;
+          _model = v;
+        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
+          _revision = v;
+        } else if (strncmp(buf, "flags", sizeof("flags") - 1) == 0) {
+          if (strstr(p+1, "dcpop")) {
+            guarantee(_features & CPU_DCPOP, "dcpop availability should be consistent");
+          }
+        }
+      }
+    }
+    fclose(f);
+  }
+  guarantee(cpu_lines == os::processor_count(), "core count should be consistent");
+}

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -100,7 +100,6 @@ void VM_Version::get_os_cpu_info() {
     _zva_length = 4 << (dczid_el0 & 0xf);
   }
 
-  int cpu_lines = 0;
   if (FILE *f = fopen("/proc/cpuinfo", "r")) {
     // need a large buffer as the flags line may include lots of text
     char buf[1024], *p;
@@ -109,7 +108,6 @@ void VM_Version::get_os_cpu_info() {
         long v = strtol(p+1, NULL, 0);
         if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
           _cpu = v;
-          cpu_lines++;
         } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
           _variant = v;
         } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
@@ -126,5 +124,4 @@ void VM_Version::get_os_cpu_info() {
     }
     fclose(f);
   }
-  guarantee(cpu_lines == os::processor_count(), "core count should be consistent");
 }

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -62,19 +62,7 @@
 void VM_Version::get_os_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);
-
-<<<<<<< HEAD
-  static_assert(CPU_FP      == HWCAP_FP);
-  static_assert(CPU_ASIMD   == HWCAP_ASIMD);
-  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM);
-  static_assert(CPU_AES     == HWCAP_AES);
-  static_assert(CPU_PMULL   == HWCAP_PMULL);
-  static_assert(CPU_SHA1    == HWCAP_SHA1);
-  static_assert(CPU_SHA2    == HWCAP_SHA2);
-  static_assert(CPU_CRC32   == HWCAP_CRC32);
-  static_assert(CPU_LSE     == HWCAP_ATOMICS);
-  static_assert(CPU_DCPOP   == HWCAP_DCPOP);
-=======
+  
   static_assert(CPU_FP      == HWCAP_FP,      "Flag CPU_FP must follow Linux HWCAP");
   static_assert(CPU_ASIMD   == HWCAP_ASIMD,   "Flag CPU_ASIMD must follow Linux HWCAP");
   static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM, "Flag CPU_EVTSTRM must follow Linux HWCAP");
@@ -85,10 +73,6 @@ void VM_Version::get_os_cpu_info() {
   static_assert(CPU_CRC32   == HWCAP_CRC32,   "Flag CPU_CRC32 must follow Linux HWCAP");
   static_assert(CPU_LSE     == HWCAP_ATOMICS, "Flag CPU_LSE must follow Linux HWCAP");
   static_assert(CPU_DCPOP   == HWCAP_DCPOP,   "Flag CPU_DCPOP must follow Linux HWCAP");
-  static_assert(CPU_SHA3    == HWCAP_SHA3,    "Flag CPU_SHA3 must follow Linux HWCAP");
-  static_assert(CPU_SHA512  == HWCAP_SHA512,  "Flag CPU_SHA512 must follow Linux HWCAP");
-  static_assert(CPU_SVE     == HWCAP_SVE,     "Flag CPU_SVE must follow Linux HWCAP");
->>>>>>> da48003abd2... 8255975: Fix AArch64 OpenJDK build failure with gcc-5
   _features = auxv & (
       HWCAP_FP      |
       HWCAP_ASIMD   |

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -59,39 +59,9 @@
 #define HWCAP_DCPOP (1<<16)
 #endif
 
-#ifndef HWCAP_SHA512
-#define HWCAP_SHA512 (1 << 21)
-#endif
-
-#ifndef HWCAP_SVE
-#define HWCAP_SVE (1 << 22)
-#endif
-
-#ifndef HWCAP2_SVE2
-#define HWCAP2_SVE2 (1 << 1)
-#endif
-
-#ifndef PR_SVE_GET_VL
-// For old toolchains which do not have SVE related macros defined.
-#define PR_SVE_SET_VL   50
-#define PR_SVE_GET_VL   51
-#endif
-
-int VM_Version::get_current_sve_vector_length() {
-  assert(_features & CPU_SVE, "should not call this");
-  return prctl(PR_SVE_GET_VL);
-}
-
-int VM_Version::set_and_get_current_sve_vector_lenght(int length) {
-  assert(_features & CPU_SVE, "should not call this");
-  int new_length = prctl(PR_SVE_SET_VL, length);
-  return new_length;
-}
-
 void VM_Version::get_os_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);
-  uint64_t auxv2 = getauxval(AT_HWCAP2);
 
   static_assert(CPU_FP      == HWCAP_FP);
   static_assert(CPU_ASIMD   == HWCAP_ASIMD);
@@ -103,8 +73,6 @@ void VM_Version::get_os_cpu_info() {
   static_assert(CPU_CRC32   == HWCAP_CRC32);
   static_assert(CPU_LSE     == HWCAP_ATOMICS);
   static_assert(CPU_DCPOP   == HWCAP_DCPOP);
-  static_assert(CPU_SHA512  == HWCAP_SHA512);
-  static_assert(CPU_SVE     == HWCAP_SVE);
   _features = auxv & (
       HWCAP_FP      |
       HWCAP_ASIMD   |
@@ -115,11 +83,7 @@ void VM_Version::get_os_cpu_info() {
       HWCAP_SHA2    |
       HWCAP_CRC32   |
       HWCAP_ATOMICS |
-      HWCAP_DCPOP   |
-      HWCAP_SHA512  |
-      HWCAP_SVE);
-
-  if (auxv2 & HWCAP2_SVE2) _features |= CPU_SVE2;
+      HWCAP_DCPOP);
 
   uint64_t ctr_el0;
   uint64_t dczid_el0;

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2019, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,7 @@ void VM_Version::get_os_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);
 
+<<<<<<< HEAD
   static_assert(CPU_FP      == HWCAP_FP);
   static_assert(CPU_ASIMD   == HWCAP_ASIMD);
   static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM);
@@ -73,6 +74,21 @@ void VM_Version::get_os_cpu_info() {
   static_assert(CPU_CRC32   == HWCAP_CRC32);
   static_assert(CPU_LSE     == HWCAP_ATOMICS);
   static_assert(CPU_DCPOP   == HWCAP_DCPOP);
+=======
+  static_assert(CPU_FP      == HWCAP_FP,      "Flag CPU_FP must follow Linux HWCAP");
+  static_assert(CPU_ASIMD   == HWCAP_ASIMD,   "Flag CPU_ASIMD must follow Linux HWCAP");
+  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM, "Flag CPU_EVTSTRM must follow Linux HWCAP");
+  static_assert(CPU_AES     == HWCAP_AES,     "Flag CPU_AES must follow Linux HWCAP");
+  static_assert(CPU_PMULL   == HWCAP_PMULL,   "Flag CPU_PMULL must follow Linux HWCAP");
+  static_assert(CPU_SHA1    == HWCAP_SHA1,    "Flag CPU_SHA1 must follow Linux HWCAP");
+  static_assert(CPU_SHA2    == HWCAP_SHA2,    "Flag CPU_SHA2 must follow Linux HWCAP");
+  static_assert(CPU_CRC32   == HWCAP_CRC32,   "Flag CPU_CRC32 must follow Linux HWCAP");
+  static_assert(CPU_LSE     == HWCAP_ATOMICS, "Flag CPU_LSE must follow Linux HWCAP");
+  static_assert(CPU_DCPOP   == HWCAP_DCPOP,   "Flag CPU_DCPOP must follow Linux HWCAP");
+  static_assert(CPU_SHA3    == HWCAP_SHA3,    "Flag CPU_SHA3 must follow Linux HWCAP");
+  static_assert(CPU_SHA512  == HWCAP_SHA512,  "Flag CPU_SHA512 must follow Linux HWCAP");
+  static_assert(CPU_SVE     == HWCAP_SVE,     "Flag CPU_SVE must follow Linux HWCAP");
+>>>>>>> da48003abd2... 8255975: Fix AArch64 OpenJDK build failure with gcc-5
   _features = auxv & (
       HWCAP_FP      |
       HWCAP_ASIMD   |

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -718,7 +718,7 @@
 #ifdef AARCH64
 
 #define VM_STRUCTS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field) \
-  static_field(VM_Version, _psr_info.dczid_el0, uint32_t)               \
+  static_field(VM_Version, _zva_length, int)                            \
   volatile_nonstatic_field(JavaFrameAnchor, _last_Java_fp, intptr_t*)
 
 #define VM_INT_CONSTANTS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant) \

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotLIRGenerator.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotLIRGenerator.java
@@ -555,7 +555,7 @@ public class AArch64HotSpotLIRGenerator extends AArch64LIRGenerator implements H
 
         boolean isDcZvaProhibited = true;
         int zvaLength = 0;
-        if (GraalHotSpotVMConfig.JDK >= 16) {
+        if (GraalHotSpotVMConfig.JDK >= 16) { // TODO: fix GraalHotSpotVMConfig.JDK >= 16
             zvaLength = config.zvaLength;
             isDcZvaProhibited = 0 == config.zvaLength;
         } else {

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -708,7 +708,7 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10,
                     (JVMCI ? jvmciGE(JVMCI_19_3_b04) : (JDK == 14 || JDK == 15)) && osArch.equals("aarch64"));
 
-    public final int zvaLength = getFieldValue("VM_Version::_zva_length", Integer.class, "int", 0, JDK >= 16 && osArch.equals("aarch64"));
+    public final int zvaLength = getFieldValue("VM_Version::_zva_length", Integer.class, "int", 0, JDK >= 16 && osArch.equals("aarch64")); // TODO: fix JDK >= 16
 
     // FIXME This is only temporary until the GC code is changed.
     public final boolean inlineContiguousAllocationSupported = getFieldValue("CompilerToVM::Data::_supports_inline_contig_alloc", Boolean.class);

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -705,7 +705,10 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     // ARMv8-A architecture reference manual D12.2.35 Data Cache Zero ID register says:
     // * BS, bits [3:0] indicate log2 of the DC ZVA block size in (4-byte) words.
     // * DZP, bit [4] of indicates whether use of DC ZVA instruction is prohibited.
-    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10, (JVMCI ? jvmciGE(JVMCI_19_3_b04) : JDK >= 14) && osArch.equals("aarch64"));
+    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10,
+                    (JVMCI ? jvmciGE(JVMCI_19_3_b04) : (JDK == 14 || JDK == 15)) && osArch.equals("aarch64"));
+
+    public final int zvaLength = getFieldValue("VM_Version::_zva_length", Integer.class, "int", 0, JDK >= 16 && osArch.equals("aarch64"));
 
     // FIXME This is only temporary until the GC code is changed.
     public final boolean inlineContiguousAllocationSupported = getFieldValue("CompilerToVM::Data::_supports_inline_contig_alloc", Boolean.class);


### PR DESCRIPTION
Ссылка **_на первую версию этого пулл реквеста_**, где мы обсудили, по-моему, все кроме graal-а: https://github.com/azul-research/jdk15u-dev/pull/18

**Переношу этот рефакторинг кода:** https://github.com/openjdk/jdk/pull/154, ему как раз соответствует [JDK 8253015](https://bugs.openjdk.java.net/browse/JDK-8253015).<br/>Что и почему я при переносе изменил:

* убрал все, что касалось **SVE**: его поддержка появилась только в jdk 16
   * JBS: https://bugs.openjdk.java.net/browse/JDK-8231441
   * jdk commit: https://github.com/openjdk/jdk/commit/9b5a9b61899cf649104c0ff70e14549f64a89561 
 
* убрал **MD5 Intrinsics**, так как они тоже появились только в jdk 16
   * появились в jdk 16 для x86, JBS: https://bugs.openjdk.java.net/browse/JDK-8250902
   * для AArch64 еще unresolved, JBS: https://bugs.openjdk.java.net/browse/JDK-8251216
   * собираются бэкпортировать в 11-pool (что это?), но еще не готово, JBS: https://bugs.openjdk.java.net/browse/JDK-8251319 

* убрал **SHA512**, так как его поддержали тоже только в jdk 16
   * JBS: https://bugs.openjdk.java.net/browse/JDK-8165404 
 
* добавил комментарии с `TODO` к **изменениям в graal-e**, в которых проверялось условие `JDK >= 16`
   * как я понял, основной рефактор кода, который я бэкпортирую, затронул и graal => после того, как этот рефактор ушел в jdk, изменения в graal-е попросили так же отдельно добавить в сам graal (чтобы не терялась синхронизация)
   * что действительно произошло: https://github.com/oracle/graal/pull/2861
   * однако как адаптировать проверку 16 версии, я пока не понимаю, поэтому и оставил `TODO`
   * в текущей версии graal-а, например, эти изменения никак не модифицировались: [раз](https://github.com/oracle/graal/blob/fa3259d594d295a07cad4122e1422734aa4af436/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotLIRGenerator.java#L473), [два](https://github.com/oracle/graal/blob/fa3259d594d295a07cad4122e1422734aa4af436/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java#L571)
   * @AntonKozlov здесь мне нужна ~психо~логическая помощь

Вместе с основным бэкпортом рефакторинга кода **переношу еще 3 коммита, исправляющих в нем ошибки**:
* аккуратное удаление проверки `guarantee(cpu_lines == os::processor_count(), "core count should be consistent");` и связанных с нею идейно штук:
  * просто ее удаление: https://github.com/openjdk/jdk/pull/983
  * удаление строк, связанных с не всегда работающим определением флага CPU_A53MAC через число cpu: https://github.com/openjdk/jdk/pull/1084
* исправление `static_assert`-ов: https://github.com/openjdk/jdk/pull/1088