### PR TITLE
Change build system for macOS/AArch64

### DIFF
--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -87,6 +88,14 @@ if [ "x$OUT" = x ]; then
     elif [ `uname -m` = mips64el ]; then
       OUT=mips64el-unknown-linux-gnu
     fi
+  fi
+fi
+
+# Test and fix cpu on macos-aarch64, uname -p reports arm, buildsys expects aarch64
+echo $OUT | grep arm-apple-darwin > /dev/null 2> /dev/null
+if test $? = 0; then
+  if [ `uname -m` = arm64 ]; then
+    OUT=aarch64`echo $OUT | sed -e 's/[^-]*//'`
   fi
 fi
 

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -125,19 +125,31 @@ AC_DEFUN([FLAGS_SETUP_MACOSX_VERSION],
 [
   # Additional macosx handling
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+    # The expected format for <version> is either nn.n.n or nn.nn.nn. See
+    # /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/AvailabilityVersions.h
+
     # MACOSX_VERSION_MIN specifies the lowest version of Macosx that the built
     # binaries should be compatible with, even if compiled on a newer version
     # of the OS. It currently has a hard coded value. Setting this also limits
     # exposure to API changes in header files. Bumping this is likely to
     # require code changes to build.
+<<<<<<< HEAD
     MACOSX_VERSION_MIN=10.9.0
+||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
+    MACOSX_VERSION_MIN=10.12.0
+=======
+    if test "x$OPENJDK_TARGET_CPU_ARCH" = xaarch64; then
+      MACOSX_VERSION_MIN=11.00.00
+    else
+      MACOSX_VERSION_MIN=10.12.0
+    fi
+>>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
     MACOSX_VERSION_MIN_NODOTS=${MACOSX_VERSION_MIN//\./}
 
     AC_SUBST(MACOSX_VERSION_MIN)
 
     # Setting --with-macosx-version-max=<version> makes it an error to build or
-    # link to macosx APIs that are newer than the given OS version. The expected
-    # format for <version> is either nn.n.n or nn.nn.nn. See /usr/include/AvailabilityMacros.h.
+    # link to macosx APIs that are newer than the given OS version.
     AC_ARG_WITH([macosx-version-max], [AS_HELP_STRING([--with-macosx-version-max],
         [error on use of newer functionality. @<:@macosx@:>@])],
         [

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -133,17 +133,11 @@ AC_DEFUN([FLAGS_SETUP_MACOSX_VERSION],
     # of the OS. It currently has a hard coded value. Setting this also limits
     # exposure to API changes in header files. Bumping this is likely to
     # require code changes to build.
-<<<<<<< HEAD
-    MACOSX_VERSION_MIN=10.9.0
-||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
-    MACOSX_VERSION_MIN=10.12.0
-=======
     if test "x$OPENJDK_TARGET_CPU_ARCH" = xaarch64; then
       MACOSX_VERSION_MIN=11.00.00
     else
-      MACOSX_VERSION_MIN=10.12.0
+      MACOSX_VERSION_MIN=10.9.0
     fi
->>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
     MACOSX_VERSION_MIN_NODOTS=${MACOSX_VERSION_MIN//\./}
 
     AC_SUBST(MACOSX_VERSION_MIN)

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -241,7 +241,7 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_AOT],
         test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
       AC_MSG_RESULT([yes])
     else
-      AC_MSG_RESULT([no, $OPENJDK_TARGET_CPU])
+      AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
       AVAILABLE=false
     fi
 
@@ -263,11 +263,13 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_CDS],
 [
   JVM_FEATURES_CHECK_AVAILABILITY(cds, [
     AC_MSG_CHECKING([if platform is supported by CDS])
-    if test "x$OPENJDK_TARGET_OS" != xaix; then
-      AC_MSG_RESULT([yes])
-    else
-      AC_MSG_RESULT([no, $OPENJDK_TARGET_OS])
+    if test "x$OPENJDK_TARGET_OS" = xaix || \
+        ( test "x$OPENJDK_TARGET_OS" = "xmacosx" && \
+        test "x$OPENJDK_TARGET_CPU" = "xaarch64" ) ; then
+      AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
       AVAILABLE=false
+    else
+      AC_MSG_RESULT([yes])
     fi
   ])
 ])

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -1180,7 +1180,7 @@ define SetupNativeCompilationBody
                 # This only works if the openjdk_codesign identity is present on the system. Let
                 # silently fail otherwise.
                 ifneq ($(CODESIGN), )
-		  $(CODESIGN) -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime \
+		  $(CODESIGN) -f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime \
 		      --entitlements $$(call GetEntitlementsFile, $$@) $$@
                 endif
   endif

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -88,27 +88,9 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     ADLCFLAGS += -DAIX=1
   else ifeq ($(call isTargetOs, macosx), true)
     ADLCFLAGS += -D_ALLBSD_SOURCE=1 -D_GNU_SOURCE=1
-<<<<<<< HEAD
-||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
-  else ifeq ($(call isTargetOs, windows), true)
-    ifeq ($(call isTargetCpuBits, 64), true)
-      ADLCFLAGS += -D_WIN64=1
-    endif
     ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
       ADLCFLAGS += -DR18_RESERVED
     endif
-=======
-    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
-      ADLCFLAGS += -DR18_RESERVED
-    endif
-  else ifeq ($(call isTargetOs, windows), true)
-    ifeq ($(call isTargetCpuBits, 64), true)
-      ADLCFLAGS += -D_WIN64=1
-    endif
-    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
-      ADLCFLAGS += -DR18_RESERVED
-    endif
->>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
   endif
 
   ifeq ($(call isTargetOs, windows), false)

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,27 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     ADLCFLAGS += -DAIX=1
   else ifeq ($(call isTargetOs, macosx), true)
     ADLCFLAGS += -D_ALLBSD_SOURCE=1 -D_GNU_SOURCE=1
+<<<<<<< HEAD
+||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
+  else ifeq ($(call isTargetOs, windows), true)
+    ifeq ($(call isTargetCpuBits, 64), true)
+      ADLCFLAGS += -D_WIN64=1
+    endif
+    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
+      ADLCFLAGS += -DR18_RESERVED
+    endif
+=======
+    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
+      ADLCFLAGS += -DR18_RESERVED
+    endif
+  else ifeq ($(call isTargetOs, windows), true)
+    ifeq ($(call isTargetCpuBits, 64), true)
+      ADLCFLAGS += -D_WIN64=1
+    endif
+    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
+      ADLCFLAGS += -DR18_RESERVED
+    endif
+>>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
   endif
 
   ifeq ($(call isTargetOs, windows), false)

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -466,7 +466,8 @@ else
         maybe-uninitialized class-memaccess
    HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
         tautological-constant-out-of-range-compare int-to-pointer-cast \
-        undef missing-field-initializers range-loop-analysis
+        undef missing-field-initializers range-loop-analysis \
+        deprecated-declarations c++11-narrowing
    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138
 
    LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)

--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -31,7 +31,7 @@ ifeq ($(call isTargetOs, linux), true)
   SA_CFLAGS := -D_FILE_OFFSET_BITS=64
 
 else ifeq ($(call isTargetOs, macosx), true)
-  SA_CFLAGS := -Damd64 -D_GNU_SOURCE -mno-omit-leaf-frame-pointer \
+  SA_CFLAGS := -D_GNU_SOURCE -mno-omit-leaf-frame-pointer \
       -mstack-alignment=16 -fPIC
   LIBSA_EXTRA_SRC := $(SUPPORT_OUTPUTDIR)/gensrc/jdk.hotspot.agent
 else ifeq ($(call isTargetOs, windows), true)

--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2015, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -58,7 +58,7 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 
 #define COMPRESSED_CLASS_POINTERS_DEPENDS_ON_COMPRESSED_OOPS false
 
-#if defined(_WIN64)
+#if defined(__APPLE__) || defined(_WIN64)
 #define R18_RESERVED
 #define R18_RESERVED_ONLY(code) code
 #define NOT_R18_RESERVED(code)

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -70,6 +70,9 @@ public:
   // The CPU implementer codes can be found in
   // ARM Architecture Reference Manual ARMv8, for ARMv8-A architecture profile
   // https://developer.arm.com/docs/ddi0487/latest
+  // Arm can assign codes that are not published in the manual.
+  // Apple's code is defined in
+  // https://github.com/apple/darwin-xnu/blob/33eb983/osfmk/arm/cpuid.h#L62
   enum Family {
     CPU_AMPERE    = 0xC0,
     CPU_ARM       = 'A',
@@ -84,6 +87,7 @@ public:
     CPU_QUALCOM   = 'Q',
     CPU_MARVELL   = 'V',
     CPU_INTEL     = 'i',
+    CPU_APPLE     = 'a',
   };
 
   enum Feature_Flag {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -220,6 +220,8 @@ static char cpu_arch[] = "i386";
 static char cpu_arch[] = "amd64";
 #elif defined(ARM)
 static char cpu_arch[] = "arm";
+#elif defined(AARCH64)
+static char cpu_arch[] = "aarch64";
 #elif defined(PPC32)
 static char cpu_arch[] = "ppc";
 #else
@@ -3206,7 +3208,7 @@ int os::active_processor_count() {
   return _processor_count;
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__x86_64__)
 uint os::processor_id() {
   // Get the initial APIC id and return the associated processor id. The initial APIC
   // id is limited to 8-bits, which means we can have at most 256 unique APIC ids. If

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,6 +209,8 @@ static InvocationFunctions *GetExportedJNIFunctions() {
 #if defined(__i386__)
         preferredJVM = "client";
 #elif defined(__x86_64__)
+        preferredJVM = "server";
+#elif defined(__aarch64__)
         preferredJVM = "server";
 #else
 #error "Unknown architecture - needs definition"

--- a/src/java.security.jgss/share/native/libj2gss/gssapi.h
+++ b/src/java.security.jgss/share/native/libj2gss/gssapi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#if defined(TARGET_OS_MAC)
+// Condition was copied from
+// Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/gssapi/gssapi.h
+#if TARGET_OS_MAC && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #    pragma pack(push,2)
 #endif
 
@@ -695,7 +697,7 @@ GSS_DLLIMP OM_uint32 gss_canonicalize_name(
         gss_name_t *            /* output_name */
 );
 
-#if defined(TARGET_OS_MAC)
+#if TARGET_OS_MAC && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #    pragma pack(pop)
 #endif
 

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -1,12 +1,6 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
-||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
-=======
  * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
->>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -1,5 +1,12 @@
 /*
+<<<<<<< HEAD
  * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+=======
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
+>>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,14 +49,10 @@
 #import <sys/ptrace.h>
 #include "libproc_impl.h"
 
-#define UNSUPPORTED_ARCH "Unsupported architecture!"
-
-#if defined(x86_64) && !defined(amd64)
-#define amd64 1
-#endif
-
-#if amd64
+#if defined(amd64)
 #include "sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext.h"
+#elif defined(aarch64)
+#include "sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext.h"
 #else
 #error UNSUPPORTED_ARCH
 #endif
@@ -162,20 +165,20 @@ static struct ps_prochandle* get_proc_handle(JNIEnv* env, jobject this_obj) {
   return (struct ps_prochandle*)(intptr_t)ptr;
 }
 
-#if defined(__i386__)
-    #define hsdb_thread_state_t     x86_thread_state32_t
-    #define hsdb_float_state_t      x86_float_state32_t
-    #define HSDB_THREAD_STATE       x86_THREAD_STATE32
-    #define HSDB_FLOAT_STATE        x86_FLOAT_STATE32
-    #define HSDB_THREAD_STATE_COUNT x86_THREAD_STATE32_COUNT
-    #define HSDB_FLOAT_STATE_COUNT  x86_FLOAT_STATE32_COUNT
-#elif defined(__x86_64__)
+#if defined(amd64)
     #define hsdb_thread_state_t     x86_thread_state64_t
     #define hsdb_float_state_t      x86_float_state64_t
     #define HSDB_THREAD_STATE       x86_THREAD_STATE64
     #define HSDB_FLOAT_STATE        x86_FLOAT_STATE64
     #define HSDB_THREAD_STATE_COUNT x86_THREAD_STATE64_COUNT
     #define HSDB_FLOAT_STATE_COUNT  x86_FLOAT_STATE64_COUNT
+#elif defined(aarch64)
+    #define hsdb_thread_state_t     arm_thread_state64_t
+    #define hsdb_float_state_t      arm_neon_state64_t
+    #define HSDB_THREAD_STATE       ARM_THREAD_STATE64
+    #define HSDB_FLOAT_STATE        ARM_NEON_STATE64
+    #define HSDB_THREAD_STATE_COUNT ARM_THREAD_STATE64_COUNT
+    #define HSDB_FLOAT_STATE_COUNT  ARM_NEON_STATE64_COUNT
 #else
     #error UNSUPPORTED_ARCH
 #endif
@@ -494,11 +497,21 @@ bool fill_java_threads(JNIEnv* env, jobject this_obj, struct ps_prochandle* ph) 
       lwpid_t  uid = cinfos[j];
       uint64_t beg = cinfos[j + 1];
       uint64_t end = cinfos[j + 2];
+#if defined(amd64)
       if ((regs.r_rsp < end && regs.r_rsp >= beg) ||
           (regs.r_rbp < end && regs.r_rbp >= beg)) {
         set_lwp_id(ph, i, uid);
         break;
       }
+#elif defined(aarch64)
+      if ((regs.r_sp < end && regs.r_sp >= beg) ||
+          (regs.r_fp < end && regs.r_fp >= beg)) {
+        set_lwp_id(ph, i, uid);
+        break;
+      }
+#else
+#error UNSUPPORTED_ARCH
+#endif
     }
   }
   (*env)->ReleaseLongArrayElements(env, thrinfos, (jlong*)cinfos, 0);
@@ -530,13 +543,21 @@ jlongArray getThreadIntegerRegisterSetFromCore(JNIEnv *env, jobject this_obj, lo
 
 #undef NPRGREG
 #undef REG_INDEX
-#if amd64
+#if defined(amd64)
 #define NPRGREG sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_NPRGREG
 #define REG_INDEX(reg) sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_##reg
+#elif defined(aarch64)
+#define NPRGREG sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext_NPRGREG
+#define REG_INDEX(reg) sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext_##reg
+#else
+#error UNSUPPORTED_ARCH
+#endif
 
   array = (*env)->NewLongArray(env, NPRGREG);
   CHECK_EXCEPTION_(0);
   regs = (*env)->GetLongArrayElements(env, array, &isCopy);
+
+#if defined(amd64)
 
   regs[REG_INDEX(R15)] = gregs.r_r15;
   regs[REG_INDEX(R14)] = gregs.r_r14;
@@ -566,8 +587,47 @@ jlongArray getThreadIntegerRegisterSetFromCore(JNIEnv *env, jobject this_obj, lo
   regs[REG_INDEX(TRAPNO)] = gregs.r_trapno;
   regs[REG_INDEX(RFL)]    = gregs.r_rflags;
 
+#elif defined(aarch64)
+
+  regs[REG_INDEX(R0)] = gregs.r_r0;
+  regs[REG_INDEX(R1)] = gregs.r_r1;
+  regs[REG_INDEX(R2)] = gregs.r_r2;
+  regs[REG_INDEX(R3)] = gregs.r_r3;
+  regs[REG_INDEX(R4)] = gregs.r_r4;
+  regs[REG_INDEX(R5)] = gregs.r_r5;
+  regs[REG_INDEX(R6)] = gregs.r_r6;
+  regs[REG_INDEX(R7)] = gregs.r_r7;
+  regs[REG_INDEX(R8)] = gregs.r_r8;
+  regs[REG_INDEX(R9)] = gregs.r_r9;
+  regs[REG_INDEX(R10)] = gregs.r_r10;
+  regs[REG_INDEX(R11)] = gregs.r_r11;
+  regs[REG_INDEX(R12)] = gregs.r_r12;
+  regs[REG_INDEX(R13)] = gregs.r_r13;
+  regs[REG_INDEX(R14)] = gregs.r_r14;
+  regs[REG_INDEX(R15)] = gregs.r_r15;
+  regs[REG_INDEX(R16)] = gregs.r_r16;
+  regs[REG_INDEX(R17)] = gregs.r_r17;
+  regs[REG_INDEX(R18)] = gregs.r_r18;
+  regs[REG_INDEX(R19)] = gregs.r_r19;
+  regs[REG_INDEX(R20)] = gregs.r_r20;
+  regs[REG_INDEX(R21)] = gregs.r_r21;
+  regs[REG_INDEX(R22)] = gregs.r_r22;
+  regs[REG_INDEX(R23)] = gregs.r_r23;
+  regs[REG_INDEX(R24)] = gregs.r_r24;
+  regs[REG_INDEX(R25)] = gregs.r_r25;
+  regs[REG_INDEX(R26)] = gregs.r_r26;
+  regs[REG_INDEX(R27)] = gregs.r_r27;
+  regs[REG_INDEX(R28)] = gregs.r_r28;
+  regs[REG_INDEX(FP)] = gregs.r_fp;
+  regs[REG_INDEX(LR)] = gregs.r_lr;
+  regs[REG_INDEX(SP)] = gregs.r_sp;
+  regs[REG_INDEX(PC)] = gregs.r_pc;
+
+#else
+#error UNSUPPORTED_ARCH
+#endif
+
   (*env)->ReleaseLongArrayElements(env, array, regs, JNI_COMMIT);
-#endif /* amd64 */
   return array;
 }
 
@@ -656,16 +716,22 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_getThreadIntegerRegisterSet0(
     return NULL;
   }
 
-#if amd64
+#undef NPRGREG
+#if defined(amd64)
 #define NPRGREG sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_NPRGREG
-#undef REG_INDEX
-#define REG_INDEX(reg) sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_##reg
+#elif defined(aarch64)
+#define NPRGREG sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext_NPRGREG
+#else
+#error UNSUPPORTED_ARCH
+#endif
 
   // 64 bit
   print_debug("Getting threads for a 64-bit process\n");
   registerArray = (*env)->NewLongArray(env, NPRGREG);
   CHECK_EXCEPTION_(0);
   primitiveArray = (*env)->GetLongArrayElements(env, registerArray, NULL);
+
+#if defined(amd64)
 
   primitiveArray[REG_INDEX(R15)] = state.__r15;
   primitiveArray[REG_INDEX(R14)] = state.__r14;
@@ -695,14 +761,50 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_getThreadIntegerRegisterSet0(
   primitiveArray[REG_INDEX(DS)] = 0;
   primitiveArray[REG_INDEX(FSBASE)] = 0;
   primitiveArray[REG_INDEX(GSBASE)] = 0;
-  print_debug("set registers\n");
 
-  (*env)->ReleaseLongArrayElements(env, registerArray, primitiveArray, 0);
+#elif defined(aarch64)
+
+  primitiveArray[REG_INDEX(R0)] = state.__x[0];
+  primitiveArray[REG_INDEX(R1)] = state.__x[1];
+  primitiveArray[REG_INDEX(R2)] = state.__x[2];
+  primitiveArray[REG_INDEX(R3)] = state.__x[3];
+  primitiveArray[REG_INDEX(R4)] = state.__x[4];
+  primitiveArray[REG_INDEX(R5)] = state.__x[5];
+  primitiveArray[REG_INDEX(R6)] = state.__x[6];
+  primitiveArray[REG_INDEX(R7)] = state.__x[7];
+  primitiveArray[REG_INDEX(R8)] = state.__x[8];
+  primitiveArray[REG_INDEX(R9)] = state.__x[9];
+  primitiveArray[REG_INDEX(R10)] = state.__x[10];
+  primitiveArray[REG_INDEX(R11)] = state.__x[11];
+  primitiveArray[REG_INDEX(R12)] = state.__x[12];
+  primitiveArray[REG_INDEX(R13)] = state.__x[13];
+  primitiveArray[REG_INDEX(R14)] = state.__x[14];
+  primitiveArray[REG_INDEX(R15)] = state.__x[15];
+  primitiveArray[REG_INDEX(R16)] = state.__x[16];
+  primitiveArray[REG_INDEX(R17)] = state.__x[17];
+  primitiveArray[REG_INDEX(R18)] = state.__x[18];
+  primitiveArray[REG_INDEX(R19)] = state.__x[19];
+  primitiveArray[REG_INDEX(R20)] = state.__x[20];
+  primitiveArray[REG_INDEX(R21)] = state.__x[21];
+  primitiveArray[REG_INDEX(R22)] = state.__x[22];
+  primitiveArray[REG_INDEX(R23)] = state.__x[23];
+  primitiveArray[REG_INDEX(R24)] = state.__x[24];
+  primitiveArray[REG_INDEX(R25)] = state.__x[25];
+  primitiveArray[REG_INDEX(R26)] = state.__x[26];
+  primitiveArray[REG_INDEX(R27)] = state.__x[27];
+  primitiveArray[REG_INDEX(R28)] = state.__x[28];
+  primitiveArray[REG_INDEX(FP)] = state.__fp;
+  primitiveArray[REG_INDEX(LR)] = state.__lr;
+  primitiveArray[REG_INDEX(SP)] = state.__sp;
+  primitiveArray[REG_INDEX(PC)] = state.__pc;
 
 #else
 #error UNSUPPORTED_ARCH
-#endif /* amd64 */
+#endif
 
+  print_debug("set registers\n");
+
+  (*env)->ReleaseLongArrayElements(env, registerArray, primitiveArray, 0);
   return registerArray;
 }
 

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.h
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.h
@@ -1,5 +1,12 @@
 /*
+<<<<<<< HEAD
  * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+=======
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
+>>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +37,16 @@
 #include "libproc.h"
 #include "symtab.h"
 
+#define UNSUPPORTED_ARCH "Unsupported architecture!"
+
+#if defined(__x86_64__) && !defined(amd64)
+#define amd64 1
+#endif
+
+#if defined(__arm64__) && !defined(aarch64)
+#define aarch64 1
+#endif
+
 #ifdef __APPLE__
 #include <inttypes.h>     // for PRIx64, 32, ...
 #include <pthread.h>
@@ -41,6 +58,7 @@
 #define register_t uint64_t
 #endif
 
+#if defined(amd64)
 /*** registers copied from bsd/amd64 */
 typedef struct reg {
   register_t      r_r15;
@@ -70,6 +88,48 @@ typedef struct reg {
   register_t      r_rsp;
   register_t      r_ss;          // not used
 } reg;
+
+#elif defined(aarch64)
+/*** registers copied from bsd/arm64 */
+typedef struct reg {
+  register_t      r_r0;
+  register_t      r_r1;
+  register_t      r_r2;
+  register_t      r_r3;
+  register_t      r_r4;
+  register_t      r_r5;
+  register_t      r_r6;
+  register_t      r_r7;
+  register_t      r_r8;
+  register_t      r_r9;
+  register_t      r_r10;
+  register_t      r_r11;
+  register_t      r_r12;
+  register_t      r_r13;
+  register_t      r_r14;
+  register_t      r_r15;
+  register_t      r_r16;
+  register_t      r_r17;
+  register_t      r_r18;
+  register_t      r_r19;
+  register_t      r_r20;
+  register_t      r_r21;
+  register_t      r_r22;
+  register_t      r_r23;
+  register_t      r_r24;
+  register_t      r_r25;
+  register_t      r_r26;
+  register_t      r_r27;
+  register_t      r_r28;
+  register_t      r_fp;
+  register_t      r_lr;
+  register_t      r_sp;
+  register_t      r_pc;
+} reg;
+
+#else
+#error UNSUPPORTED_ARCH
+#endif
 
 // convenient defs
 typedef struct mach_header_64 mach_header_64;

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.h
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.h
@@ -1,12 +1,6 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
-||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
-=======
  * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
->>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -1,5 +1,12 @@
 /*
+<<<<<<< HEAD
  * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+=======
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
+>>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +39,14 @@
 #include "ps_core_common.h"
 
 #ifdef __APPLE__
+#if defined(amd64)
 #include "sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext.h"
+#elif defined(aarch64)
+#include "sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext.h"
+#else
+#error UNSUPPORTED_ARCH
 #endif
+#endif /* __APPLE__ */
 
 // This file has the libproc implementation to read core files.
 // For live processes, refer to ps_proc.c. Portions of this is adapted
@@ -194,6 +207,8 @@ static ps_prochandle_ops core_ops = {
 void print_thread(sa_thread_info *threadinfo) {
   print_debug("thread added: %d\n", threadinfo->lwp_id);
   print_debug("registers:\n");
+
+#if defined(amd64)
   print_debug("  r_r15: 0x%" PRIx64 "\n", threadinfo->regs.r_r15);
   print_debug("  r_r14: 0x%" PRIx64 "\n", threadinfo->regs.r_r14);
   print_debug("  r_r13: 0x%" PRIx64 "\n", threadinfo->regs.r_r13);
@@ -215,6 +230,45 @@ void print_thread(sa_thread_info *threadinfo) {
   print_debug("  r_cs:  0x%" PRIx64 "\n", threadinfo->regs.r_cs);
   print_debug("  r_rsp: 0x%" PRIx64 "\n", threadinfo->regs.r_rsp);
   print_debug("  r_rflags: 0x%" PRIx64 "\n", threadinfo->regs.r_rflags);
+
+#elif defined(aarch64)
+  print_debug(" r_r0:  0x%" PRIx64 "\n", threadinfo->regs.r_r0);
+  print_debug(" r_r1:  0x%" PRIx64 "\n", threadinfo->regs.r_r1);
+  print_debug(" r_r2:  0x%" PRIx64 "\n", threadinfo->regs.r_r2);
+  print_debug(" r_r3:  0x%" PRIx64 "\n", threadinfo->regs.r_r3);
+  print_debug(" r_r4:  0x%" PRIx64 "\n", threadinfo->regs.r_r4);
+  print_debug(" r_r5:  0x%" PRIx64 "\n", threadinfo->regs.r_r5);
+  print_debug(" r_r6:  0x%" PRIx64 "\n", threadinfo->regs.r_r6);
+  print_debug(" r_r7:  0x%" PRIx64 "\n", threadinfo->regs.r_r7);
+  print_debug(" r_r8:  0x%" PRIx64 "\n", threadinfo->regs.r_r8);
+  print_debug(" r_r9:  0x%" PRIx64 "\n", threadinfo->regs.r_r9);
+  print_debug(" r_r10: 0x%" PRIx64 "\n", threadinfo->regs.r_r10);
+  print_debug(" r_r11: 0x%" PRIx64 "\n", threadinfo->regs.r_r11);
+  print_debug(" r_r12: 0x%" PRIx64 "\n", threadinfo->regs.r_r12);
+  print_debug(" r_r13: 0x%" PRIx64 "\n", threadinfo->regs.r_r13);
+  print_debug(" r_r14: 0x%" PRIx64 "\n", threadinfo->regs.r_r14);
+  print_debug(" r_r15: 0x%" PRIx64 "\n", threadinfo->regs.r_r15);
+  print_debug(" r_r16: 0x%" PRIx64 "\n", threadinfo->regs.r_r16);
+  print_debug(" r_r17: 0x%" PRIx64 "\n", threadinfo->regs.r_r17);
+  print_debug(" r_r18: 0x%" PRIx64 "\n", threadinfo->regs.r_r18);
+  print_debug(" r_r19: 0x%" PRIx64 "\n", threadinfo->regs.r_r19);
+  print_debug(" r_r20: 0x%" PRIx64 "\n", threadinfo->regs.r_r20);
+  print_debug(" r_r21: 0x%" PRIx64 "\n", threadinfo->regs.r_r21);
+  print_debug(" r_r22: 0x%" PRIx64 "\n", threadinfo->regs.r_r22);
+  print_debug(" r_r23: 0x%" PRIx64 "\n", threadinfo->regs.r_r23);
+  print_debug(" r_r24: 0x%" PRIx64 "\n", threadinfo->regs.r_r24);
+  print_debug(" r_r25: 0x%" PRIx64 "\n", threadinfo->regs.r_r25);
+  print_debug(" r_r26: 0x%" PRIx64 "\n", threadinfo->regs.r_r26);
+  print_debug(" r_r27: 0x%" PRIx64 "\n", threadinfo->regs.r_r27);
+  print_debug(" r_r28: 0x%" PRIx64 "\n", threadinfo->regs.r_r28);
+  print_debug(" r_fp:  0x%" PRIx64 "\n", threadinfo->regs.r_fp);
+  print_debug(" r_lr:  0x%" PRIx64 "\n", threadinfo->regs.r_lr);
+  print_debug(" r_sp:  0x%" PRIx64 "\n", threadinfo->regs.r_sp);
+  print_debug(" r_pc:  0x%" PRIx64 "\n", threadinfo->regs.r_pc);
+
+#else
+#error UNSUPPORTED_ARCH
+#endif
 }
 
 // read all segments64 commands from core file
@@ -266,6 +320,7 @@ static bool read_core_segments(struct ps_prochandle* ph) {
           goto err;
         }
         size += sizeof(thread_fc);
+#if defined(amd64)
         if (fc.flavor == x86_THREAD_STATE) {
           x86_thread_state_t thrstate;
           if (read(fd, (void *)&thrstate, sizeof(x86_thread_state_t)) != sizeof(x86_thread_state_t)) {
@@ -325,6 +380,90 @@ static bool read_core_segments(struct ps_prochandle* ph) {
           }
           size += sizeof(x86_exception_state_t);
         }
+
+#elif defined(aarch64)
+        if (fc.flavor == ARM_THREAD_STATE64) {
+          arm_thread_state64_t thrstate;
+          if (read(fd, (void *)&thrstate, sizeof(arm_thread_state64_t)) != sizeof(arm_thread_state64_t)) {
+            printf("Reading flavor, count failed.\n");
+            goto err;
+          }
+          size += sizeof(arm_thread_state64_t);
+          // create thread info list, update lwp_id later
+          sa_thread_info* newthr = add_thread_info(ph, (pthread_t) -1, (lwpid_t) num_threads++);
+          if (newthr == NULL) {
+            printf("create thread_info failed\n");
+            goto err;
+          }
+
+          // note __DARWIN_UNIX03 depengs on other definitions
+#if __DARWIN_UNIX03
+#define get_register_v(regst, regname) \
+  regst.__##regname
+#else
+#define get_register_v(regst, regname) \
+  regst.##regname
+#endif // __DARWIN_UNIX03
+          newthr->regs.r_r0  = get_register_v(thrstate, x[0]);
+          newthr->regs.r_r1  = get_register_v(thrstate, x[1]);
+          newthr->regs.r_r2  = get_register_v(thrstate, x[2]);
+          newthr->regs.r_r3  = get_register_v(thrstate, x[3]);
+          newthr->regs.r_r4  = get_register_v(thrstate, x[4]);
+          newthr->regs.r_r5  = get_register_v(thrstate, x[5]);
+          newthr->regs.r_r6  = get_register_v(thrstate, x[6]);
+          newthr->regs.r_r7  = get_register_v(thrstate, x[7]);
+          newthr->regs.r_r8  = get_register_v(thrstate, x[8]);
+          newthr->regs.r_r9  = get_register_v(thrstate, x[9]);
+          newthr->regs.r_r10 = get_register_v(thrstate, x[10]);
+          newthr->regs.r_r11 = get_register_v(thrstate, x[11]);
+          newthr->regs.r_r12 = get_register_v(thrstate, x[12]);
+          newthr->regs.r_r13 = get_register_v(thrstate, x[13]);
+          newthr->regs.r_r14 = get_register_v(thrstate, x[14]);
+          newthr->regs.r_r15 = get_register_v(thrstate, x[15]);
+          newthr->regs.r_r16 = get_register_v(thrstate, x[16]);
+          newthr->regs.r_r17 = get_register_v(thrstate, x[17]);
+          newthr->regs.r_r18 = get_register_v(thrstate, x[18]);
+          newthr->regs.r_r19 = get_register_v(thrstate, x[19]);
+          newthr->regs.r_r20 = get_register_v(thrstate, x[20]);
+          newthr->regs.r_r21 = get_register_v(thrstate, x[21]);
+          newthr->regs.r_r22 = get_register_v(thrstate, x[22]);
+          newthr->regs.r_r23 = get_register_v(thrstate, x[23]);
+          newthr->regs.r_r24 = get_register_v(thrstate, x[24]);
+          newthr->regs.r_r25 = get_register_v(thrstate, x[25]);
+          newthr->regs.r_r26 = get_register_v(thrstate, x[26]);
+          newthr->regs.r_r27 = get_register_v(thrstate, x[27]);
+          newthr->regs.r_r28 = get_register_v(thrstate, x[28]);
+          newthr->regs.r_fp  = get_register_v(thrstate, fp);
+          newthr->regs.r_lr  = get_register_v(thrstate, lr);
+          newthr->regs.r_sp  = get_register_v(thrstate, sp);
+          newthr->regs.r_pc  = get_register_v(thrstate, pc);
+          print_thread(newthr);
+        } else if (fc.flavor == ARM_NEON_STATE64) {
+          arm_neon_state64_t flstate;
+          if (read(fd, (void *)&flstate, sizeof(arm_neon_state64_t)) != sizeof(arm_neon_state64_t)) {
+            printf("Reading flavor, count failed.\n");
+            goto err;
+          }
+          size += sizeof(arm_neon_state64_t);
+        } else if (fc.flavor == ARM_EXCEPTION_STATE64) {
+          arm_exception_state64_t excpstate;
+          if (read(fd, (void *)&excpstate, sizeof(arm_exception_state64_t)) != sizeof(arm_exception_state64_t)) {
+            printf("Reading flavor, count failed.\n");
+            goto err;
+          }
+          size += sizeof(arm_exception_state64_t);
+        } else if (fc.flavor == ARM_DEBUG_STATE64) {
+          arm_debug_state64_t dbgstate;
+          if (read(fd, (void *)&dbgstate, sizeof(arm_debug_state64_t)) != sizeof(arm_debug_state64_t)) {
+            printf("Reading flavor, count failed.\n");
+            goto err;
+          }
+          size += sizeof(arm_debug_state64_t);
+        }
+
+#else
+#error UNSUPPORTED_ARCH
+#endif
       }
     }
   }

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -1,12 +1,6 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
-||||||| parent of dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
-=======
  * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
->>>>>>> dbc9e4b50cd (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/hsdis/Makefile
+++ b/src/utils/hsdis/Makefile
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # The Universal Permissive License (UPL), Version 1.0
@@ -107,13 +108,19 @@ else
 ifeq ($(OS),Darwin)
 CPU             = $(shell uname -m)
 ARCH1=$(CPU:x86_64=amd64)
-ARCH=$(ARCH1:i686=i386)
+ARCH2=$(ARCH1:arm64=aarch64)
+ARCH=$(ARCH2:i686=i386)
+CONFIGURE_ARGS/aarch64= --enable-targets=aarch64-darwin
+CONFIGURE_ARGS = $(CONFIGURE_ARGS/$(ARCH))
 ifdef LP64
 CFLAGS/amd64    += -m64
 else
-ARCH=$(ARCH1:amd64=i386)
+ARCH=$(ARCH2:amd64=i386)
 CFLAGS/i386     += -m32
 endif # LP64
+ifeq ($(CPU), arm64)
+CFLAGS/aarch64  += -m64
+endif # arm64
 CFLAGS          += $(CFLAGS/$(ARCH))
 CFLAGS          += -fPIC
 OS              = macosx


### PR DESCRIPTION
Патч содержит изменения для build системы, а также добавляет знание о macos/aarch64 через define-

Я сделал cherry-pick большого патча и выбрал нужные изменения, закоммитил их и после этого сделал исправление конфликтов

Изменения:
config.guess: привился чисто
Смысл изменения: Добавляем знание о arm-apple-darwin

**make/autoconf/flags.m4**: здесь в патче была выше версия (10.12.0), я заменил её на 10.9.0, которая сейчас есть в jdk15
Смысл изменения: Если у нас macos-aarch64, то минимальную macos ставим 11

jvm-features.m4: привился чисто
Смысл изменения: в macos-aarch64 недоступен CDS, поэтому нужно поставить false, если видим macos-aarch64, также добавили вывод os в дополнение к процессору

NativeCompilation.gmk: привился чисто
Смысл изменения: добавлили флаг '-f' option will replace an existing signature if one exists

**GensrcAdlc.gmk**: в патче здесь уже был windows, поэтому автоматически не привился, я убрал часть с windows
Смысл изменения: если у нас macos-aarch64, то нам нужен R18_RESERVED

Awt2dLibraries.gmk: привился чисто
Смысл изменения: В патче здесь добавляли 2 опции deprecated-declarations и c++11-narrowing, то есть ворнинги, которые нужно игнорировать

Lib.gmk: привился чисто
Смысл изменения: убрали проставление amd64, если у нас macos. Проставление amd64 или aarch64 теперь происходит в коде через define

globalDefinitions_aarch64.hpp: привился чисто
Смысл изменения: если у нас macos-aarch64, то нам нужен R18_RESERVED

vm_version_aarch64.hpp: привился чисто
Смысл изменения: добавили код ('a') процессоров Apple 

os_bsd.cpp: привился чисто
Смысл изменения: добавили знание о aarch64 в bsd и сделали функцию uint os::processor_id() только для x86

java_md_macosx.m: привился чисто
Смысл изменения: добавили знание о aarch64

gssapi.h: привился чисто
Смысл изменения: делаем pragma pack(push,2) и pragma pack(pop) только если у нас macos не на arm

MacosxDebuggerLocal.m: привился чисто, кроме лицензии
Смысл изменения: добавили код для aarch64 рядом с amd64, код похож на код для amd64, только имена регистров и их количество другие

libproc_impl.h: привился чисто, кроме лицензии
Смысл изменения: делаем объявление amd64 или aarch64, которое убрали из Lib.gmk и также добавляем структуру с регистрами для aarch64

ps_core.c: привился чисто, кроме лицензии
Смысл изменения: добавили код для aarch64 рядом с amd64, опять же, код похож, в нем просто заменили имена регистров и типов

Makefile: привился чисто
Смысл изменения: добавили знание о aarch64