### PR TITLE
Support macOS Aarch64 ABI in Interpreter

### DIFF
--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,9 +58,14 @@ FloatRegister InterpreterRuntime::SignatureHandlerGenerator::next_fpr() {
   return fnoreg;
 }
 
-int InterpreterRuntime::SignatureHandlerGenerator::next_stack_offset() {
+// On macos/aarch64 native stack is packed, int/float are using only 4 bytes
+// on stack. Natural alignment for types are still in place,
+// for example double/long should be 8 bytes aligned.
+
+int InterpreterRuntime::SignatureHandlerGenerator::next_stack_offset(unsigned elem_size) {
+  MACOS_ONLY(_stack_offset = align_up(_stack_offset, elem_size));
   int ret = _stack_offset;
-  _stack_offset += wordSize;
+  _stack_offset += NOT_MACOS(wordSize) MACOS_ONLY(elem_size);
   return ret;
 }
 
@@ -71,6 +77,30 @@ InterpreterRuntime::SignatureHandlerGenerator::SignatureHandlerGenerator(
   _stack_offset = 0;
 }
 
+void InterpreterRuntime::SignatureHandlerGenerator::pass_byte() {
+  const Address src(from(), Interpreter::local_offset_in_bytes(offset()));
+
+  Register reg = next_gpr();
+  if (reg != noreg) {
+    __ ldr(reg, src);
+  } else {
+    __ ldrb(r0, src);
+    __ strb(r0, Address(to(), next_stack_offset(sizeof(jbyte))));
+  }
+}
+
+void InterpreterRuntime::SignatureHandlerGenerator::pass_short() {
+  const Address src(from(), Interpreter::local_offset_in_bytes(offset()));
+
+  Register reg = next_gpr();
+  if (reg != noreg) {
+    __ ldr(reg, src);
+  } else {
+    __ ldrh(r0, src);
+    __ strh(r0, Address(to(), next_stack_offset(sizeof(jshort))));
+  }
+}
+
 void InterpreterRuntime::SignatureHandlerGenerator::pass_int() {
   const Address src(from(), Interpreter::local_offset_in_bytes(offset()));
 
@@ -79,7 +109,7 @@ void InterpreterRuntime::SignatureHandlerGenerator::pass_int() {
     __ ldr(reg, src);
   } else {
     __ ldrw(r0, src);
-    __ strw(r0, Address(to(), next_stack_offset()));
+    __ strw(r0, Address(to(), next_stack_offset(sizeof(jint))));
   }
 }
 
@@ -91,7 +121,7 @@ void InterpreterRuntime::SignatureHandlerGenerator::pass_long() {
     __ ldr(reg, src);
   } else {
     __ ldr(r0, src);
-    __ str(r0, Address(to(), next_stack_offset()));
+    __ str(r0, Address(to(), next_stack_offset(sizeof(jlong))));
   }
 }
 
@@ -103,7 +133,7 @@ void InterpreterRuntime::SignatureHandlerGenerator::pass_float() {
     __ ldrs(reg, src);
   } else {
     __ ldrw(r0, src);
-    __ strw(r0, Address(to(), next_stack_offset()));
+    __ strw(r0, Address(to(), next_stack_offset(sizeof(jfloat))));
   }
 }
 
@@ -115,7 +145,7 @@ void InterpreterRuntime::SignatureHandlerGenerator::pass_double() {
     __ ldrd(reg, src);
   } else {
     __ ldr(r0, src);
-    __ str(r0, Address(to(), next_stack_offset()));
+    __ str(r0, Address(to(), next_stack_offset(sizeof(jdouble))));
   }
 }
 
@@ -139,7 +169,8 @@ void InterpreterRuntime::SignatureHandlerGenerator::pass_object() {
     __ cbnz(temp(), L);
     __ mov(r0, zr);
     __ bind(L);
-    __ str(r0, Address(to(), next_stack_offset()));
+    static_assert(sizeof(jobject) == wordSize, "");
+    __ str(r0, Address(to(), next_stack_offset(sizeof(jobject))));
   }
 }
 
@@ -164,7 +195,7 @@ class SlowSignatureHandler
   : public NativeSignatureIterator {
  private:
   address   _from;
-  intptr_t* _to;
+  char*     _to;
   intptr_t* _int_args;
   intptr_t* _fp_args;
   intptr_t* _fp_identifiers;
@@ -199,21 +230,38 @@ class SlowSignatureHandler
     return -1;
   }
 
-  void pass_stack(intptr_t value) {
-    *_to++ = value;
+  template<typename T>
+  void pass_stack(T value) {
+    MACOS_ONLY(_to = align_up(_to, sizeof(value)));
+    *(T *)_to = value;
+    _to += NOT_MACOS(wordSize) MACOS_ONLY(sizeof(value));
+  }
+
+  virtual void pass_byte() {
+    jbyte value = *(jbyte*)single_slot_addr();
+    if (pass_gpr(value) < 0) {
+      pass_stack<>(value);
+    }
+  }
+
+  virtual void pass_short() {
+    jshort value = *(jshort*)single_slot_addr();
+    if (pass_gpr(value) < 0) {
+      pass_stack<>(value);
+    }
   }
 
   virtual void pass_int() {
     jint value = *(jint*)single_slot_addr();
     if (pass_gpr(value) < 0) {
-      pass_stack(value);
+      pass_stack<>(value);
     }
   }
 
   virtual void pass_long() {
     intptr_t value = *double_slot_addr();
     if (pass_gpr(value) < 0) {
-      pass_stack(value);
+      pass_stack<>(value);
     }
   }
 
@@ -221,14 +269,14 @@ class SlowSignatureHandler
     intptr_t* addr = single_slot_addr();
     intptr_t value = *addr == 0 ? NULL : (intptr_t)addr;
     if (pass_gpr(value) < 0) {
-      pass_stack(value);
+      pass_stack<>(value);
     }
   }
 
   virtual void pass_float() {
     jint value = *(jint*)single_slot_addr();
     if (pass_fpr(value) < 0) {
-      pass_stack(value);
+      pass_stack<>(value);
     }
   }
 
@@ -238,7 +286,7 @@ class SlowSignatureHandler
     if (0 <= arg) {
       *_fp_identifiers |= (1ull << arg); // mark as double
     } else {
-      pass_stack(value);
+      pass_stack<>(value);
     }
   }
 
@@ -247,7 +295,7 @@ class SlowSignatureHandler
     : NativeSignatureIterator(method)
   {
     _from = from;
-    _to   = to;
+    _to   = (char *)to;
 
     _int_args = to - (method->is_static() ? 16 : 17);
     _fp_args =  to - 8;

--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.hpp
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +39,8 @@ class SignatureHandlerGenerator: public NativeSignatureIterator {
   unsigned int _num_reg_int_args;
   int _stack_offset;
 
+  void pass_byte();
+  void pass_short();
   void pass_int();
   void pass_long();
   void pass_float();
@@ -46,7 +49,7 @@ class SignatureHandlerGenerator: public NativeSignatureIterator {
 
   Register next_gpr();
   FloatRegister next_fpr();
-  int next_stack_offset();
+  int next_stack_offset(unsigned elem_size);
 
  public:
   // Creation

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1,15 +1,7 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
-||||||| parent of 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
-=======
  * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
->>>>>>> 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1,6 +1,15 @@
 /*
+<<<<<<< HEAD
  * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
+||||||| parent of 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
+=======
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
+>>>>>>> 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -773,6 +782,11 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
         if (int_args < Argument::n_int_register_parameters_c) {
           regs[i].set1(INT_ArgReg[int_args++]->as_VMReg());
         } else {
+#ifdef __APPLE__
+          // Less-than word types are stored one after another.
+          // The code is unable to handle this so bailout.
+          return -1;
+#endif
           regs[i].set1(VMRegImpl::stack2reg(stk_args));
           stk_args += 2;
         }
@@ -795,6 +809,11 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
         if (fp_args < Argument::n_float_register_parameters_c) {
           regs[i].set1(FP_ArgReg[fp_args++]->as_VMReg());
         } else {
+#ifdef __APPLE__
+          // Less-than word types are stored one after another.
+          // The code is unable to handle this so bailout.
+          return -1;
+#endif
           regs[i].set1(VMRegImpl::stack2reg(stk_args));
           stk_args += 2;
         }
@@ -1355,6 +1374,10 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // they require.
   int out_arg_slots;
   out_arg_slots = c_calling_convention(out_sig_bt, out_regs, NULL, total_c_args);
+
+  if (out_arg_slots < 0) {
+    return NULL;
+  }
 
   // Compute framesize for the wrapper.  We need to handlize all oops in
   // incoming registers

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -743,7 +743,7 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   return AdapterHandlerLibrary::new_entry(fingerprint, i2c_entry, c2i_entry, c2i_unverified_entry, c2i_no_clinit_check_entry);
 }
 
-int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
+static int c_calling_convention_priv(const BasicType *sig_bt,
                                          VMRegPair *regs,
                                          VMRegPair *regs2,
                                          int total_args_passed) {
@@ -830,6 +830,16 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
     }
 
   return stk_args;
+}
+
+int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
+                                         VMRegPair *regs,
+                                         VMRegPair *regs2,
+                                         int total_args_passed)
+{
+  int result = c_calling_convention_priv(sig_bt, regs, regs2, total_args_passed);
+  guarantee(result >= 0, "Unsupported arguments configuration");
+  return result;
 }
 
 // On 64 bit we will store integer like items to the stack as
@@ -1365,7 +1375,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // Now figure out where the args must be stored and how much stack space
   // they require.
   int out_arg_slots;
-  out_arg_slots = c_calling_convention(out_sig_bt, out_regs, NULL, total_c_args);
+  out_arg_slots = c_calling_convention_priv(out_sig_bt, out_regs, NULL, total_c_args);
 
   if (out_arg_slots < 0) {
     return NULL;

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -242,6 +242,8 @@ class MaskFillerForNative: public NativeSignatureIterator {
   }
 
  public:
+  void pass_byte()                               { /* ignore */ }
+  void pass_short()                              { /* ignore */ }
   void pass_int()                                { /* ignore */ }
   void pass_long()                               { /* ignore */ }
   void pass_float()                              { /* ignore */ }

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -386,10 +387,14 @@ class NativeSignatureIterator: public SignatureIterator {
   void do_type(BasicType type) {
     switch (type) {
     case T_BYTE:
-    case T_SHORT:
-    case T_INT:
     case T_BOOLEAN:
+      pass_byte();  _jni_offset++; _offset++;
+      break;
     case T_CHAR:
+    case T_SHORT:
+      pass_short();  _jni_offset++; _offset++;
+      break;
+    case T_INT:
       pass_int();    _jni_offset++; _offset++;
       break;
     case T_FLOAT:
@@ -423,6 +428,8 @@ class NativeSignatureIterator: public SignatureIterator {
   virtual void pass_long()             = 0;
   virtual void pass_object()           = 0;  // objects, arrays, inlines
   virtual void pass_float()            = 0;
+  virtual void pass_byte()             { pass_int(); };
+  virtual void pass_short()            { pass_int(); };
 #ifdef _LP64
   virtual void pass_double()           = 0;
 #else


### PR DESCRIPTION
Сделал cherry-pick патча без лишних коммитов. Все изменения привились чисто (кроме лицензии). Скорее всего все эти изменения из https://github.com/openjdk/jdk/pull/2200/commits/368f06e1cb965a68997cad0722aabcbe1068aad7