### PR TITLE
Update tests and JDK code for macOS/Aarch64

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -237,8 +237,9 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_AOT],
   JVM_FEATURES_CHECK_AVAILABILITY(aot, [
     AC_MSG_CHECKING([if platform is supported by AOT])
     # AOT is only available where JVMCI is available since it requires JVMCI.
-    if test "x$OPENJDK_TARGET_CPU" = "xx86_64" || \
-        test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+    if test "x$OPENJDK_TARGET_CPU" = "xx86_64"; then
+      AC_MSG_RESULT([yes])
+    elif test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64"; then
       AC_MSG_RESULT([yes])
     else
       AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])

--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -36,7 +36,7 @@ NativeCallStack::NativeCallStack(int toSkip, bool fillStack) :
     // to call os::get_native_stack. A tail call is used if _NMT_NOINLINE_ is not defined
     // (which means this is not a slowdebug build), and we are on 64-bit (except Windows).
     // This is not necessarily a rule, but what has been obvserved to date.
-#if (defined(_NMT_NOINLINE_) || defined(_WINDOWS) || !defined(_LP64))
+#if (defined(_NMT_NOINLINE_) || defined(_WINDOWS) || !defined(_LP64) || (defined(BSD) && defined (__aarch64__)))
     // Not a tail call.
     toSkip++;
 #if (defined(_NMT_NOINLINE_) && defined(BSD) && defined(_LP64))

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,58 @@ public class CompressedClassPointers {
         output.shouldHaveExitValue(0);
     }
 
+<<<<<<< HEAD
+||||||| parent of 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
+    // Settings as in largeHeapTest() except for max heap size. We make max heap
+    // size even larger such that it cannot fit into lower 32G but not too large
+    // for compressed oops.
+    // We expect a zerobased ccs.
+    public static void largeHeapAbove32GTest() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-Xmx31g",
+            "-XX:-UseAOT", // AOT explicitly set klass shift to 3.
+            logging_option,
+            "-Xshare:off",
+            "-XX:+VerifyBeforeGC", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        if (testNarrowKlassBase()) {
+            output.shouldContain("Narrow klass base: 0x0000000000000000");
+            if (!Platform.isAArch64() && !Platform.isOSX()) {
+                output.shouldContain("Narrow klass shift: 0");
+            }
+        }
+        output.shouldHaveExitValue(0);
+    }
+
+=======
+    // Settings as in largeHeapTest() except for max heap size. We make max heap
+    // size even larger such that it cannot fit into lower 32G but not too large
+    // for compressed oops.
+    // We expect a zerobased ccs.
+    public static void largeHeapAbove32GTest() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-Xmx31g",
+            "-XX:-UseAOT", // AOT explicitly set klass shift to 3.
+            logging_option,
+            "-Xshare:off",
+            "-XX:+VerifyBeforeGC", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        if (testNarrowKlassBase()) {
+            if (!(Platform.isAArch64() && Platform.isOSX())) { // see JDK-8262895
+                output.shouldContain("Narrow klass base: 0x0000000000000000");
+                if (!Platform.isAArch64() && !Platform.isOSX()) {
+                    output.shouldContain("Narrow klass shift: 0");
+                }
+            }
+        }
+        output.shouldHaveExitValue(0);
+    }
+
+>>>>>>> 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
     // Using large paged heap, metaspace uses small pages.
     public static void largePagesForHeapTest() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,58 +105,6 @@ public class CompressedClassPointers {
         output.shouldHaveExitValue(0);
     }
 
-<<<<<<< HEAD
-||||||| parent of 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
-    // Settings as in largeHeapTest() except for max heap size. We make max heap
-    // size even larger such that it cannot fit into lower 32G but not too large
-    // for compressed oops.
-    // We expect a zerobased ccs.
-    public static void largeHeapAbove32GTest() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-XX:+UnlockDiagnosticVMOptions",
-            "-XX:+UnlockExperimentalVMOptions",
-            "-Xmx31g",
-            "-XX:-UseAOT", // AOT explicitly set klass shift to 3.
-            logging_option,
-            "-Xshare:off",
-            "-XX:+VerifyBeforeGC", "-version");
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (testNarrowKlassBase()) {
-            output.shouldContain("Narrow klass base: 0x0000000000000000");
-            if (!Platform.isAArch64() && !Platform.isOSX()) {
-                output.shouldContain("Narrow klass shift: 0");
-            }
-        }
-        output.shouldHaveExitValue(0);
-    }
-
-=======
-    // Settings as in largeHeapTest() except for max heap size. We make max heap
-    // size even larger such that it cannot fit into lower 32G but not too large
-    // for compressed oops.
-    // We expect a zerobased ccs.
-    public static void largeHeapAbove32GTest() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-XX:+UnlockDiagnosticVMOptions",
-            "-XX:+UnlockExperimentalVMOptions",
-            "-Xmx31g",
-            "-XX:-UseAOT", // AOT explicitly set klass shift to 3.
-            logging_option,
-            "-Xshare:off",
-            "-XX:+VerifyBeforeGC", "-version");
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (testNarrowKlassBase()) {
-            if (!(Platform.isAArch64() && Platform.isOSX())) { // see JDK-8262895
-                output.shouldContain("Narrow klass base: 0x0000000000000000");
-                if (!Platform.isAArch64() && !Platform.isOSX()) {
-                    output.shouldContain("Narrow klass shift: 0");
-                }
-            }
-        }
-        output.shouldHaveExitValue(0);
-    }
-
->>>>>>> 5e4dae92d17 (8253795: Implementation of JEP 391: macOS/AArch64 Port)
     // Using large paged heap, metaspace uses small pages.
     public static void largePagesForHeapTest() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -531,6 +531,8 @@ class CheckedFeatures {
         {"linux-s390x",     "com.sun.jdi.SharedMemoryAttach"},
         {"macosx-amd64",    "com.sun.jdi.SharedMemoryAttach"},
         {"mac-x64",         "com.sun.jdi.SharedMemoryAttach"},
+        {"macosx-aarch64",  "com.sun.jdi.SharedMemoryAttach"},
+        {"mac-aarch64",     "com.sun.jdi.SharedMemoryAttach"},
         {"aix-ppc64",       "com.sun.jdi.SharedMemoryAttach"},
 
             // listening connectors
@@ -554,6 +556,8 @@ class CheckedFeatures {
         {"linux-s390x",     "com.sun.jdi.SharedMemoryListen"},
         {"macosx-amd64",    "com.sun.jdi.SharedMemoryListen"},
         {"mac-x64",         "com.sun.jdi.SharedMemoryListen"},
+        {"macosx-aarch64",  "com.sun.jdi.SharedMemoryListen"},
+        {"mac-aarch64",     "com.sun.jdi.SharedMemoryListen"},
         {"aix-ppc64",       "com.sun.jdi.SharedMemoryListen"},
 
             // launching connectors
@@ -611,8 +615,14 @@ class CheckedFeatures {
         {"macosx-amd64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
         {"macosx-amd64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
-        {"mac-x64",         "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-        {"mac-x64",         "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+        {"mac-x64",          "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"mac-x64",          "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+
+        {"macosx-aarch64",   "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"macosx-aarch64",   "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+
+        {"mac-aarch64",      "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"mac-aarch64",      "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
         {"aix-ppc64",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
         {"aix-ppc64",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
@@ -629,6 +639,8 @@ class CheckedFeatures {
         {"linux-s390x",     "dt_shmem"},
         {"macosx-amd64",    "dt_shmem"},
         {"mac-x64",         "dt_shmem"},
+        {"macosx-aarch64",  "dt_shmem"},
+        {"mac-aarch64",     "dt_shmem"},
         {"aix-ppc64",       "dt_shmem"},
     };
 }


### PR DESCRIPTION
Патч включает изменения тестов, которые были в патче. Одно изменение меняет тест, которого ещё нет в jdk15, поэтому его я убрал. Также добавил сюда отключение AOT для aarch64 кроме linux